### PR TITLE
Migrate to Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+.obj
+cmake-build-debug
+.idea/workspace.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: cpp
+compiler: gcc
+before_script: mkdir -p build && cd build
+script:  cmake ${ICL_OPTIONS} .. && make -j 3
+sudo: false
+matrix:
+  include:
+    # works on Precise and Trusty
+    - addons:
+        apt:
+          packages:
+            - cmake
+            - libpng-dev
+            - libjpeg-dev
+      env:
+          - ICL_OPTIONS=""
+    - addons:
+        apt:
+          packages:
+            - cmake
+            - libpng-dev
+            - libjpeg-dev
+            - qtmultimedia5-dev
+            - libqt5opengl5-dev
+            - libglew-dev
+            - libopencv-dev
+            - ocl-icd-opencl-dev
+            - opencl-headers
+            - libeigen3-dev
+            - libmagick++-dev
+            - libfreenect-dev
+            - libxine2-dev
+            # - libpcl-dev -DBUILD_WITH_PCL=TRUE \ Cannot use PCL with travis atm
+      env:
+        - ICL_OPTIONS="\
+              -DBUILD_WITH_QT=TRUE \
+              -DBUILD_WITH_OPENCV=TRUE  \
+              -DBUILD_WITH_OPENCL=TRUE \
+              -DBUILD_WITH_EIGEN3=TRUE \
+              -DBUILD_WITH_IMAGEMAGICK=TRUE \
+              -DBUILD_WITH_V4L=TRUE \
+              -DBUILD_WITH_LIBFREENECT=TRUE \
+              -DBUILD_WITH_XINE=TRUE \
+              -DBUILD_WITH_LIBDC=TRUE \
+              "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,17 @@
 #**                                                                 **
 #*********************************************************************
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.2)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
-PROJECT(ICL)
+# ---- global definitions ----
+# todo: add "-debug" postfix here and there!
+SET(ICL_VERSION_MAJOR "10" CACHE STRING "Major project version part")
+SET(ICL_VERSION_MINOR "0" CACHE STRING "Minor project version part")
+SET(ICL_VERSION_PATCH "0" CACHE STRING "Patch project version part")
+SET(PROJECT_VERSION "${ICL_VERSION_MAJOR}.${ICL_VERSION_MINOR}.${ICL_VERSION_PATCH}")
+
+PROJECT(ICL VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 
 # ---- cmake settings ----
 INCLUDE(ICLHelperMacros)
@@ -42,9 +49,6 @@ INCLUDE(FindSSE)
 
 # for using GET_FILENAME_COMPONENT
 SET(ICL_FILE_NAME_COMPONENT_DIR PATH)
-IF(CMAKE_VERSION VERSION_LESS 2.8.12)
-  SET(ICL_FILE_NAME_COMPONENT_DIR DIRECTORY)
-ENDIF()
 set(CMAKE_CXX_STANDARD 11)
 
 IF(APPLE)
@@ -138,14 +142,9 @@ ELSE(MSVC)
   ENDIF()
 ENDIF(MSVC)
 
-# ---- global definitions ----
-# todo: add "-debug" postfix here and there!
-SET(ICL_VERSION_MAJOR "9" CACHE STRING "Major project version part")
-SET(ICL_VERSION_MINOR "13" CACHE STRING "Minor project version part")
-SET(ICL_VERSION_PATCH "0" CACHE STRING "Patch project version part")
+
 
 SET(ICL_NAME                   icl)
-SET(PROJECT_VERSION            "${ICL_VERSION_MAJOR}.${ICL_VERSION_MINOR}.${ICL_VERSION_PATCH}")
 SET(SO_VERSION                 "${ICL_VERSION_MAJOR}.${ICL_VERSION_MINOR}")
 SET(INSTALL_PATH_PREFIX        "${ICL_NAME}-${SO_VERSION}")
 SET(BINARY_PREFIX              "${ICL_NAME}-")

--- a/README.md
+++ b/README.md
@@ -1,7 +1,155 @@
-# ICL -- Image Component Library
+![](doc/icl-api/images/icl-logo-50.png) [![Build Status](https://travis-ci.org/iclcv/icl.svg?branch=master)](https://travis-ci.org/iclcv/icl)
+
+# ICL - Image Component Library
 
 ## Table of Contents
+- [Installation](#installation)
+  - [Building from source (Linux)](#building-from-source)
+  - [Homebrew (OSX)](#macos)
 - [About ICL](#about-icl)
+
+## Installation
+
+### Ubuntu (Linux)
+
+#### Building from source
+To build the minimal version of ICL, the following packages are **mandatory**:
+
+* `cmake`
+* `libjpeg-dev`
+* `libpng-dev`
+
+With a Debian-based operating system, these requirements can be installed using
+`apt`:
+
+```
+$ sudo apt-get install cmake libjpeg-dev libpng-dev
+```
+
+Clone this repository to your workspace, cd into the project folder and build the
+libraries with `cmake`
+
+```
+$ cd /path/to/workspace
+$ git clone https://github.com/iclcv/icl.git
+$ mkdir icl/build # create build folder
+$ cd icl/build
+$ cmake ..
+$ make  # optionally with -j for parallel jobs
+$ make install  # install ICL
+```
+
+However, the strength of ICL lies in its rich set of features which can be
+tailored according to your need.
+The instruction below will install dependencies
+and configure the build tool in a way to makes use of 3rd party libraries such as
+Qt, OpenCV, Point Cloud Library (PCL) and many more.
+It will also build ICL applications for fast computer vision prototyping as well as demo code
+and documentation examples.
+
+```
+$ sudo apt-get install cmake libpng-dev libjpeg-dev qtmultimedia5-dev \
+  libqt5opengl5-dev libglew-dev libopencv-dev ocl-icd-opencl-dev \
+  opencl-headers libeigen3-dev libmagick++-dev libfreenect-dev libxine2-dev \
+  libpcl-dev
+
+# clone and create build folder
+
+$ cmake .. -DBUILD_WITH_EIGEN3=TRUE -DBUILD_WITH_V4L=TRUE \
+           -DBUILD_WITH_LIBFREENECT=TRUE -DBUILD_WITH_MESASR=TRUE \
+           -DBUILD_WITH_QT=TRUE -DBUILD_WITH_OPENCL=TRUE \
+           -DBUILD_WITH_LIBDC=TRUE -DBUILD_WITH_IMAGEMAGICK=TRUE \
+           -DBUILD_EXAMPLES=ON -DBUILD_DEMOS=ON \
+           -DBUILD_WITH_OPENCV=TRUE -DBUILD_APPS=ON \
+           -DBUILD_WITH_PCL=TRUE
+$ make  # build icl
+```
+
+Let's dig bit deeper to get to know the meanings behind those flags, shall we?
+Below you will find a list of features and the `cmake` flags required to build these features as well as the required Ubuntu packages.
+
+##### Qt5 (**recommended**)
+
+The well known Qt Library is used for ICL’s rapid GUI creation toolkit. Actually Qt is also a prerequisite for most ICL applications and for the whole ICLQt module. We strongly recommend to have at least Qt support when building ICL.
+
+* flag: `-DBUILD_WITH_QT=TRUE`
+* dependencies: `qtmultimedia5-dev libqt5opengl5-dev libglew-dev`
+
+##### OpenCV (**recommended**)
+
+We use OpenCV mainly in order to provide a compatibility interface that converts OpenCV’s common image data types IplImage and CvMat into ICL’s images types and vice versa.
+
+* flag: `-DBUILD_WITH_OPENCV=TRUE`
+* dependencies: `libopencv-dev`
+
+##### OpenCL (**recommended**)
+
+OpenCL is used to significantly speed up a set of processing units using the computing units of graphics cards or other OpenCL platforms. We mainly use it for point cloud processing units located in the ICLGeom module.
+
+* flag: `-DBUILD_WITH_OPENCL=TRUE`
+* dependencies: `ocl-icd-opencl-dev opencl-headers`
+
+##### Eigen3 (**recommended**)
+
+Improves calculation speed.
+
+* flag: `-DBUILD_WITH_EIGEN3=TRUE`
+* dependencies: `libeigen3-dev`
+
+##### ImageMagick (**recommended**)
+
+ImageMagick is used to provide a large set of support image types. Most types are supported in both reading and writing.
+
+* flag: `-DBUILD_WITH_IMAGEMAGICK=TRUE`
+* dependencies: `libmagick++-dev`
+
+##### V4L2 (**recommended**)
+
+For most usb-based cameras/Webcams on linux, V4L2 can be used. While v4l2 used to be a part of the kernel-Headers in older linux version, nowerdays, it is shipped as an additional library that can usually be installed conveniently using a package manager.
+
+* flag: `-DBUILD_WITH_V4L=TRUE`
+
+##### libfreenect (*optional*)
+
+The libfreenect provides a lightweight interface for grabbing images from Microsoft Kinect cameras. The library allows to grab color, depth and IR-images and to set some internal camera properties.
+
+* flag: `-DBUILD_WITH_LIBFREENECT=TRUE`
+* dependencies: `libfreenect-dev`
+
+##### libdc1394 (*optional*)
+
+* flag: `-DBUILD_WITH_LIBDC=TRUE`
+
+##### ICL Applications
+
+Build with ICL tools
+* flag: `-DBUILD_APPS=ON`
+
+Build demos
+* flag: `-DBUILD_DEMOS=ON`
+
+Build doc examples
+* flag: `-DBUILD_EXAMPLES=ON`
+
+We **strongly** recommend to have at least Qt support when building ICL.
+But there is more! Please refer to the documentation of [optional features](http://www.iclcv.org/install/install-linux.html#optional-dependencies)
+for a complete list which includes Xine, Kinect 2, SwissRanger and more.
+
+### MacOS
+
+We provide [Homebrew](https://brew.sh/index_de.html) recipes which can be used
+to install ICL in three different flavours:
+
+```
+# has to be done just once
+$ brew tap iclcv/homebrew-formulas  
+# enables features of OpenCV, Qt, OpenGL, ImageMagick, LibAV, LibDC and LibEigen
+$ brew install icl  
+# base features plus additional functionality based on rsb, protobuf, freenect, pcl and bullet
+$ brew install icl --with-extra
+# extra features plus libusb, zmq and openni support  
+brew install icl --with-full
+```
 
 ## <a name="about-icl"></a>About ICL
 


### PR DESCRIPTION
* Push version to 10.0.0 to start a new major version after the migration (thats the main reason why I ask for review)
* Extends the readme with a 'quickstart' section and a short summary of central features.
* Adds travis build instructions for 2 jobs:
  * a minimal ICL build with just PNG and JPEG support
  * a 'common' build with OpenCV, OpenCL, Eigen etc.
* Bumps required cmake to Version 3.0 (recent cmake versions complain about not using the VERSION feature; this is the 2nd reason for my review request)

Note that the common build is limited to features available in Ubuntu 14.04. We could use docker to work around this issue but I guess IPP and such is still tough to include in these builds. However, this pull request is meant to *introduce* travis/CI to ICL and should be altered when necessary.