### PR TITLE
build ICL with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,43 @@
 language: cpp
-compiler: gcc
-before_script: mkdir -p build && cd build
-script:  cmake ${ICL_OPTIONS} .. && make -j 3
 sudo: false
-matrix:
-  include:
-    # works on Precise and Trusty
-    - addons:
-        apt:
-          packages:
-            - cmake
-            - libpng-dev
-            - libjpeg-dev
-      env:
-          - ICL_OPTIONS=""
-    - addons:
-        apt:
-          packages:
-            - cmake
-            - libpng-dev
-            - libjpeg-dev
-            - qtmultimedia5-dev
-            - libqt5opengl5-dev
-            - libglew-dev
-            - libopencv-dev
-            - ocl-icd-opencl-dev
-            - opencl-headers
-            - libeigen3-dev
-            - libmagick++-dev
-            - libfreenect-dev
-            - libxine2-dev
-            # - libpcl-dev -DBUILD_WITH_PCL=TRUE \ Cannot use PCL with travis atm
-      env:
-        - ICL_OPTIONS="\
+
+before_script:
+  - mkdir -p build
+script:
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=/tmp/icl ${ICL_OPTIONS} ..
+  - make -j 3
+  - make install
+
+# define some yaml variables
+include: &SIMPLE
+  addons:
+    apt:
+      packages:
+        - cmake
+        - libpng-dev
+        - libjpeg-dev
+  env:
+    - ICL_OPTIONS=""
+          
+include: &EXTENDED
+  <<: *SIMPLE
+  addons:
+    apt:
+      packages:
+        - qtmultimedia5-dev
+        - libqt5opengl5-dev
+        - libglew-dev
+        - libopencv-dev
+        - ocl-icd-opencl-dev
+        - opencl-headers
+        - libeigen3-dev
+        - libmagick++-dev
+        - libfreenect-dev
+        - libxine2-dev
+        # - libpcl-dev -DBUILD_WITH_PCL=TRUE \ Cannot use PCL with travis atm
+  env:
+    - ICL_OPTIONS="\
               -DBUILD_WITH_QT=TRUE \
               -DBUILD_WITH_OPENCV=TRUE  \
               -DBUILD_WITH_OPENCL=TRUE \
@@ -43,3 +48,12 @@ matrix:
               -DBUILD_WITH_XINE=TRUE \
               -DBUILD_WITH_LIBDC=TRUE \
               "
+
+matrix:
+  include:
+    - <<: *SIMPLE
+      compiler: gcc
+    - <<: *EXTENDED
+      compiler: gcc
+    - <<: *EXTENDED
+      compiler: clang

--- a/ICLCV/src/ICLCV/ImageRegion.cpp
+++ b/ICLCV/src/ICLCV/ImageRegion.cpp
@@ -459,7 +459,8 @@ namespace icl{
       const std::vector<Point> &b = getBoundary(true); // thinned boundary
       if (b.size() < 2) return b.size();
 
-      static const float length[3] = {1, 1/::cos(::atan(0.5)), 1/::cos(::atan(1.))}; // length of segment types
+      // static_cast is required here due to narrowing conventions.
+      static const float length[3] = {1, static_cast<float>(1/::cos(::atan(0.5))), static_cast<float>(1/::cos(::atan(1.)))}; // length of segment types
       int grad[3] = {0}, type; // counters for segment types
       Point pre = b[b.size()-2];
       Point cur = b[b.size()-1];

--- a/ICLCore/CMakeLists.txt
+++ b/ICLCore/CMakeLists.txt
@@ -83,6 +83,11 @@ SET(HEADERS src/ICLCore/BayerConverter.h
 IF(OpenCV_FOUND)
   LIST(APPEND SOURCES src/ICLCore/OpenCV.cpp)
   LIST(APPEND HEADERS src/ICLCore/OpenCV.h)
+  # if the error also occurs on OSX use 'MATCHES "Clang"' instead
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # Related to narrowing issues https://github.com/opencv/opencv/issues/8192
+    set_source_files_properties(src/ICLCore/OpenCV.cpp PROPERTIES COMPILE_FLAGS -Wno-narrowing)
+  endif()
 ENDIF()
 
 # ---- Library build instructions ----

--- a/ICLIO/src/ICLIO/JPEGEncoder.cpp
+++ b/ICLIO/src/ICLIO/JPEGEncoder.cpp
@@ -53,11 +53,11 @@ namespace icl{
         md->mgr.free_in_buffer = md->bufsize;  // buffer size
         md->datasize = 0;
       }
-      int empty_output_buffer (j_compress_ptr compress){
+      boolean empty_output_buffer (j_compress_ptr compress){
         MemDst *md = (MemDst*)compress->dest;
         md->mgr.next_output_byte = md->buffer;
         md->mgr.free_in_buffer = md->bufsize;
-        return true;
+        return TRUE;
       }
       void term_destination (j_compress_ptr compress){
         MemDst *md = (MemDst*)compress->dest;

--- a/ICLIO/src/ICLIO/JPEGEncoder.cpp
+++ b/ICLIO/src/ICLIO/JPEGEncoder.cpp
@@ -75,11 +75,7 @@ namespace icl{
         md->buffer = buffer;
         md->outsize = outsize;
         md->mgr.init_destination = init_destination;
-#ifdef ICL_SYSTEM_WINDOWS
-        md->mgr.empty_output_buffer = (boolean(__cdecl *)(j_compress_ptr))empty_output_buffer;
-#else
         md->mgr.empty_output_buffer = empty_output_buffer;
-#endif
         md->mgr.term_destination = term_destination;
       }
     }

--- a/ICLMath/src/ICLMath/DynMatrixUtils.cpp
+++ b/ICLMath/src/ICLMath/DynMatrixUtils.cpp
@@ -502,20 +502,8 @@ namespace icl{
     INSTANTIATE_DYN_MATRIX_MATH_OP(mul,icl::math::mulc<T>)
     INSTANTIATE_DYN_MATRIX_MATH_OP(div,icl::math::divc<T>)
 
-  // TODO: Implement for Windows
-  // GCC uses its builtin variants of pow and atan which are not available
-  // for clang. Clang falls back to std::pow/atan and requires specific type
-  // signatures for these functions.
-  #ifndef ICL_SYSTEM_WINDOWS
-    #if defined(__clang__)
-      INSTANTIATE_DYN_MATRIX_MATH_OP(pow, static_cast<T(*)(T, T)>(::pow))
-      INSTANTIATE_DYN_MATRIX_MATH_OP(arctan2, static_cast<T(*)(T, T)>(::atan2))
-    #else
-      INSTANTIATE_DYN_MATRIX_MATH_OP(pow, ::pow)
-      INSTANTIATE_DYN_MATRIX_MATH_OP(arctan2, ::atan2)
-    #endif
-  #endif
-
+    INSTANTIATE_DYN_MATRIX_MATH_OP(pow, static_cast<T(*)(T, T)>(std::pow))
+    INSTANTIATE_DYN_MATRIX_MATH_OP(arctan2, static_cast<T(*)(T, T)>(std::atan2))
   #undef INSTANTIATE_DYN_MATRIX_MATH_OP
 
     // others

--- a/ICLMath/src/ICLMath/DynMatrixUtils.cpp
+++ b/ICLMath/src/ICLMath/DynMatrixUtils.cpp
@@ -482,8 +482,7 @@ namespace icl{
   #undef INSTANTIATE_DYN_MATRIX_MATH_OP
 
 
-    // binary functions
-
+  // binary functions
   #define INSTANTIATE_DYN_MATRIX_MATH_OP(op,func)                         \
     template<class T>                                                     \
     DynMatrix<T> &matrix_##op(const DynMatrix<T> &a, const DynMatrix<T> &b, DynMatrix<T> &dst) \
@@ -502,10 +501,20 @@ namespace icl{
     INSTANTIATE_DYN_MATRIX_MATH_OP(sub,icl::math::subc<T>)
     INSTANTIATE_DYN_MATRIX_MATH_OP(mul,icl::math::mulc<T>)
     INSTANTIATE_DYN_MATRIX_MATH_OP(div,icl::math::divc<T>)
-#ifndef ICL_SYSTEM_WINDOWS // TODO: for windows // TODOW
-    INSTANTIATE_DYN_MATRIX_MATH_OP(pow,::pow)
-    INSTANTIATE_DYN_MATRIX_MATH_OP(arctan2,::atan2)
-#endif
+
+  // TODO: Implement for Windows
+  // GCC uses its builtin variants of pow and atan which are not available
+  // for clang. Clang falls back to std::pow/atan and requires specific type
+  // signatures for these functions.
+  #ifndef ICL_SYSTEM_WINDOWS
+    #if defined(__clang__)
+      INSTANTIATE_DYN_MATRIX_MATH_OP(pow, static_cast<T(*)(T, T)>(::pow))
+      INSTANTIATE_DYN_MATRIX_MATH_OP(arctan2, static_cast<T(*)(T, T)>(::atan2))
+    #else
+      INSTANTIATE_DYN_MATRIX_MATH_OP(pow, ::pow)
+      INSTANTIATE_DYN_MATRIX_MATH_OP(arctan2, ::atan2)
+    #endif
+  #endif
 
   #undef INSTANTIATE_DYN_MATRIX_MATH_OP
 
@@ -1504,4 +1513,3 @@ namespace icl{
 
   } // namespace math
 }
-

--- a/ICLQt/src/ICLQt/AbstractPlotWidget.cpp
+++ b/ICLQt/src/ICLQt/AbstractPlotWidget.cpp
@@ -140,9 +140,9 @@ namespace icl{
       }
 
       bool sendMouseEvents(AbstractPlotWidget *w, QMouseEvent *event, MouseEventType t){
-        const bool d[] = {event->buttons() & Qt::LeftButton,
-                          event->buttons() & Qt::MidButton,
-                          event->buttons() & Qt::RightButton };
+        const bool d[] = {static_cast<bool>(event->buttons() & Qt::LeftButton),
+                          static_cast<bool>(event->buttons() & Qt::MidButton),
+                          static_cast<bool>(event->buttons() & Qt::RightButton)};
 
         if(t == MouseMoveEvent && (d[0] || d[1] || d[2])) t = MouseDragEvent;
 

--- a/ICLQt/src/ICLQt/PlotWidget.cpp
+++ b/ICLQt/src/ICLQt/PlotWidget.cpp
@@ -254,7 +254,7 @@ namespace icl{
       std::vector<Point32f> data(num + !!closedLoop);
       std::copy(ps,ps+num,data.begin());
       if(closedLoop) data.back() = *ps;
-      addAnnotations('L',&data[0].x, data.size(), m_data->state.linePen, Qt::NoBrush, m_data->label, '\0');
+      addAnnotations('L',&data[0].x, data.size(), m_data->state.linePen, Qt::NoBrush, m_data->label, "\0");
     }
     void PlotWidget::linestrip(const float *xs, const float *ys, int num, bool closedLoop, int stride){
       std::vector<Point32f> data(num + !!closedLoop);

--- a/ICLUtils/src/ICLUtils/SSETypes.h
+++ b/ICLUtils/src/ICLUtils/SSETypes.h
@@ -1148,7 +1148,7 @@ namespace icl{
           return *this;
         }
 
-#ifndef ICL_SYSTEM_APPLE
+#ifndef __clang__
         inline icl128i32s& operator=(const icl128i32s &v) {
           v0 = v.v0;
           return *this;
@@ -1648,7 +1648,7 @@ namespace icl{
         return ret *= rv;
       }
 
-#ifndef ICL_SYSTEM_APPLE
+#ifndef __clang__
       inline icl128 operator/(const icl128 &lv, const icl128 &rv) {
         icl128 ret = lv;
         return ret /= rv;

--- a/ICLUtils/src/ICLUtils/Thread.cpp
+++ b/ICLUtils/src/ICLUtils/Thread.cpp
@@ -110,24 +110,30 @@ namespace icl{
     void Thread::usleep(unsigned int usec){
     #ifdef ICL_SYSTEM_WINDOWS
       Sleep(usec / 1000);
+    #elif defined(__clang__)
+      usleep(usec);
     #else
       ::usleep(usec);
     #endif
     }
 
     void Thread::msleep(unsigned int msecs){
-  #ifdef ICL_SYSTEM_WINDOWS
+    #ifdef ICL_SYSTEM_WINDOWS
       Sleep(msecs);
-  #else
+    #elif defined(__clang__)
+      usleep(msecs*1000);
+    #else
       ::usleep(msecs*1000);
-  #endif
+    #endif
     }
     void Thread::sleep(float secs){
-  #ifdef ICL_SYSTEM_WINDOWS
+    #ifdef ICL_SYSTEM_WINDOWS
       Sleep(secs*1000);
-  #else
+    #elif defined(__clang__)
+      usleep((long)secs * 1000);
+    #else
       ::usleep((long)secs * 1000000);
-  #endif
+    #endif
     }
 
     // Maybe this works


### PR DESCRIPTION
this fixes #3; 

clang also complains about minor things such as [this](https://github.com/iclcv/icl/compare/dev-clang?expand=1#diff-6d2e0156ca62fcfa14f0ea89f1ad99ebL56) returning an `int` instead of a boolean as required by the later assignment. Or adding `'\0'` as a char instead of a string. Also, a bit like #3 there is not `usleep` in the global namespace of clang.