### PR TITLE
fixup throw exception declarations

### DIFF
--- a/ICLCV/src/ICLCV/CornerDetectorCSS.cpp
+++ b/ICLCV/src/ICLCV/CornerDetectorCSS.cpp
@@ -618,7 +618,7 @@ namespace icl{
     template ICLCV_API const vector<vector<utils::Point32f> > &CornerDetectorCSS::detectCorners(const vector<vector<Point> > &boundaries, const vector<icl32f> &sigmas);
 
 
-    void CornerDetectorCSS::setPropertyValue(const std::string &propertyName, const Any &value) {
+    void CornerDetectorCSS::setPropertyValue(const std::string &propertyName, const Any &value){
       if(propertyName == "angle-threshold") angle_thresh = parse<float>(value);
       else if(propertyName == "rc-coefficient") rc_coeff = parse<float>(value);
       else if(propertyName == "sigma") sigma = parse<float>(value);

--- a/ICLCV/src/ICLCV/ImageRegion.cpp
+++ b/ICLCV/src/ICLCV/ImageRegion.cpp
@@ -666,7 +666,7 @@ namespace icl{
 
 
 
-    const std::vector<ImageRegion> &ImageRegion::getSubRegions(bool directOnly) const {
+    const std::vector<ImageRegion> &ImageRegion::getSubRegions(bool directOnly) const{
       ICLASSERT_THROW(m_data->graph, ICLException("ImageRegion::getSubRegions: no region graph information available"));
       ImageRegionData::ComplexInformation *complex = m_data->ensureComplex();
       if(directOnly && complex->directSubRegions) return *complex->directSubRegions;
@@ -697,7 +697,7 @@ namespace icl{
     }
 
 
-    const ImageRegion &ImageRegion::getParentRegion() const {
+    const ImageRegion &ImageRegion::getParentRegion() const{
       ICLASSERT_THROW(m_data->graph, ICLException("ImageRegion::getParentRegion: no region graph information available"));
       ImageRegionData::ComplexInformation *complex = m_data->ensureComplex();
 
@@ -718,7 +718,7 @@ namespace icl{
       collect_parent_regions_recursive(buf,p);
     }
 
-    const std::vector<ImageRegion> &ImageRegion::getParentTree() const {
+    const std::vector<ImageRegion> &ImageRegion::getParentTree() const{
       ICLASSERT_THROW(m_data->graph, ICLException("ImageRegion::getParentTree: no region graph information available"));
       ImageRegionData::ComplexInformation *complex = m_data->ensureComplex();
 
@@ -730,7 +730,7 @@ namespace icl{
       return *complex->parentTree;
     }
 
-    const std::vector<ImageRegion> &ImageRegion::getNeighbours() const {
+    const std::vector<ImageRegion> &ImageRegion::getNeighbours() const{
       ICLASSERT_THROW(m_data->graph, ICLException("ImageRegion::getNeighbours: no region graph information available"));
       ImageRegionData::ComplexInformation *complex = m_data->ensureComplex();
       if(complex->publicNeighbours) return *complex->publicNeighbours;
@@ -739,7 +739,7 @@ namespace icl{
       return *(complex->publicNeighbours = new std::vector<ImageRegion>(nb.begin(),nb.end()));
     }
 
-    bool ImageRegion::isBorderRegion() const {
+    bool ImageRegion::isBorderRegion() const{
       ICLASSERT_THROW(m_data->graph, ICLException("ImageRegion::isBorderRegion: no region graph information available"));
       return m_data->graph->isBorder;
     }

--- a/ICLCV/src/ICLCV/ImageRegion.h
+++ b/ICLCV/src/ICLCV/ImageRegion.h
@@ -217,24 +217,24 @@ namespace icl{
           -# There is no path from B (from ImageRegion to adjacent ImageRegion)
              to a border-region that does not cross A
       */
-      const std::vector<ImageRegion> &getSubRegions(bool directOnly=true) const ;
+      const std::vector<ImageRegion> &getSubRegions(bool directOnly=true) const;
 
       /// returns the parent regions (which might be NULL)
       /** This function is only provided if region graph information is available (see \ref GRAPH) */
-      const ImageRegion &getParentRegion() const ;
+      const ImageRegion &getParentRegion() const;
 
       /// returns the parent region and the parent's parent and so on
       /** If a parent is null, the list ends immediately. In particular, this list can be empty
           This function is only provided if region graph information is available (see \ref GRAPH)
       */
-      const std::vector<ImageRegion> &getParentTree() const ;
+      const std::vector<ImageRegion> &getParentTree() const;
 
       /// returns a list of all adjacent regions
       /** This function is only provided if region graph information is available (see \ref GRAPH) **/
-      const std::vector<ImageRegion> &getNeighbours() const ;
+      const std::vector<ImageRegion> &getNeighbours() const;
 
       /// returns whether this ImageRegion is adjacent to the image border
-      bool isBorderRegion() const ;
+      bool isBorderRegion() const;
 
       /// returns whether a given pixel position is part of the image region
       bool contains(const utils::Point &p) const;

--- a/ICLCV/src/ICLCV/RegionDetector.cpp
+++ b/ICLCV/src/ICLCV/RegionDetector.cpp
@@ -172,7 +172,7 @@ namespace icl{
     }
 
 
-    void RegionDetector::useImage(const ImgBase *image) {
+    void RegionDetector::useImage(const ImgBase *image){
       ICLASSERT_THROW(image->getDepth() != depth32f && image->getDepth() != depth64f,
                       ICLException("RegionDetector::prepareImage: depth32f and depth64f are not supported"));
       m_data->roi = image->getROI();

--- a/ICLCV/src/ICLCV/RegionDetector.h
+++ b/ICLCV/src/ICLCV/RegionDetector.h
@@ -222,7 +222,7 @@ namespace icl{
       private:
 
       /// Internally used utility function that extracts the input images ROI if necessary
-      void useImage(const core::ImgBase *image) ;
+      void useImage(const core::ImgBase *image);
 
       /// creates region-parts
       /** see \ref RA */

--- a/ICLCore/src/ICLCore/AbstractCanvas.cpp
+++ b/ICLCore/src/ICLCore/AbstractCanvas.cpp
@@ -61,7 +61,7 @@ namespace icl{
       draw_line_internal(c,a);
     }
 
-    void AbstractCanvas::sym(char c, float x, float y) {
+    void AbstractCanvas::sym(char c, float x, float y){
       const float s = state.symsize;
       switch(c){
         case 'x':
@@ -136,7 +136,7 @@ namespace icl{
     }
 
     void AbstractCanvas::image(const ImgBase *image, float xanchor, float yanchor, float alpha,
-                               scalemode sm, bool centered) {
+                               scalemode sm, bool centered){
       ICLASSERT_THROW(image,ICLException("AbstractCanvas::image: input image is null"));
 
       if(centered){

--- a/ICLCore/src/ICLCore/AbstractCanvas.h
+++ b/ICLCore/src/ICLCore/AbstractCanvas.h
@@ -143,7 +143,7 @@ namespace icl{
         stack.push_back(state);
       }
 
-      virtual void pop() {
+      virtual void pop(){
         ICLASSERT_THROW(stack.size(), utils::ICLException("AbstractCanvas::pop: stack is empty"));
         state = stack.back();
         stack.pop_back();
@@ -152,7 +152,7 @@ namespace icl{
       virtual void point(float x, float y);
       virtual void line(float x0, float y0, float x1, float y1);
       virtual void triangle(float x0, float y0, float x1, float y1, float x2, float y2);
-      virtual void sym(char c, float x, float y) ;
+      virtual void sym(char c, float x, float y);
       virtual void linestrip(int n, const float *xs, const float *ys,
                              int xStride=1, int yStride=1, bool loop=false);
       virtual void rect(float x, float y, float w, float h);
@@ -161,7 +161,7 @@ namespace icl{
       virtual void image(const ImgBase *image, float xanchor,
                          float yanchor, float alpha,
                          scalemode sm=interpolateLIN,
-                         bool centered=false)  ;
+                         bool centered=false);
       virtual void text(const std::string &t, float x, float y, bool centered = false);
 
       virtual void linecolor(float r, float g, float b, float a=255){

--- a/ICLCore/src/ICLCore/Channel.h
+++ b/ICLCore/src/ICLCore/Channel.h
@@ -339,7 +339,7 @@ namespace icl{
       }
 
       /// deeply copies the channel data (no roi support here)
-      void deepCopy(Channel<T> &other) const {
+      void deepCopy(Channel<T> &other) const{
         if(m_size != other.m_size){
           throw utils::ICLException("Channel::deepCopy: sizes differ!");
         }
@@ -348,7 +348,7 @@ namespace icl{
 
       /// deeply converts the channel data (no roi support here)
       template<class OtherT>
-      void convert(Channel<OtherT> &other) const {
+      void convert(Channel<OtherT> &other) const{
         if(m_size != other.m_size){
           throw utils::ICLException("Channel::convert: sizes differ!");
         }

--- a/ICLCore/src/ICLCore/DataSegment.h
+++ b/ICLCore/src/ICLCore/DataSegment.h
@@ -174,7 +174,7 @@ int main(){
 
       /// copies the data segment to into another element-wise
       template<class OtherT>
-      inline void deepCopy(DataSegment<OtherT,N> dst) const ;
+      inline void deepCopy(DataSegment<OtherT,N> dst) const;
 
       /// returns whether the data is packed in memory (stride is sizeof(T)*N)
       inline bool isPacked() const{
@@ -298,7 +298,7 @@ int main(){
     };
 
     template<class T, int N> template<class OtherT>
-    inline void DataSegment<T,N>::deepCopy(DataSegment<OtherT,N> dst) const {
+    inline void DataSegment<T,N>::deepCopy(DataSegment<OtherT,N> dst) const{
       ICLASSERT_THROW(getDim() == dst.getDim(),
                       utils::ICLException("error in DataSegment::deepCopy "
                                           "(source and destination dim differ)"));
@@ -344,7 +344,7 @@ int main(){
 
       /// copies the data segment to into another element-wise
       template<class OtherT>
-      inline void deepCopy(DataSegment<OtherT,1> dst) const {
+      inline void deepCopy(DataSegment<OtherT,1> dst) const{
         ICLASSERT_THROW(getDim() == dst.getDim(),
                         utils::ICLException("error in DataSegment::deepCopy "
                                             "(source and destination dim differ)"));

--- a/ICLCore/src/ICLCore/DataSegmentBase.h
+++ b/ICLCore/src/ICLCore/DataSegmentBase.h
@@ -212,7 +212,7 @@ namespace icl{
 
         /// deep copy assignment operator
         /** if source and destination lengths differ, an exception is thrown */
-        inline Bytes &operator=(const Bytes &other) {
+        inline Bytes &operator=(const Bytes &other){
           if(len != other.len){
             throw utils::ICLException("unable to assign DataSegmentBase::Bytes: lengths differ!");
           }

--- a/ICLCore/src/ICLCore/ImageSerializer.cpp
+++ b/ICLCore/src/ICLCore/ImageSerializer.cpp
@@ -66,7 +66,7 @@ namespace icl{
     }
 
 
-    ImageSerializer::ImageHeader ImageSerializer::createHeader(const ImgBase *image) {
+    ImageSerializer::ImageHeader ImageSerializer::createHeader(const ImgBase *image){
       ICLASSERT_THROW(image,ICLException(str(__FUNCTION__)+": image was null"));
       BinarySerializer ser;
       ser << (icl32s)image->getDepth()
@@ -82,7 +82,7 @@ namespace icl{
       return ser;
     }
 
-    int ImageSerializer::estimateImageDataSize(const ImgBase *image) {
+    int ImageSerializer::estimateImageDataSize(const ImgBase *image){
       ICLASSERT_THROW(image,ICLException(str(__FUNCTION__)+": image was null"));
       static const int SIZES[] = { sizeof(icl8u), sizeof(icl16s), sizeof(icl32s), sizeof(icl32f), sizeof(icl64f)};
       return  image->getChannels() * SIZES[image->getDepth()] * image->getDim();
@@ -90,7 +90,7 @@ namespace icl{
 
     void ImageSerializer::serialize(const ImgBase *image, icl8u *dst,
                                     const ImageSerializer::ImageHeader &header,
-                                    bool skipMetaData) {
+                                    bool skipMetaData){
       ICLASSERT_THROW(image,ICLException(str(__FUNCTION__)+": image was null"));
 
       if(header.size()){
@@ -120,14 +120,14 @@ namespace icl{
 
     void ImageSerializer::serialize(const ImgBase *image, std::vector<icl8u> &data,
                                     const ImageSerializer::ImageHeader &header,
-                                    bool skipMetaData) {
+                                    bool skipMetaData){
       ICLASSERT_THROW(image,ICLException(str(__FUNCTION__)+": image was null"));
 
       data.resize(estimateSerializedSize(image,skipMetaData));
       serialize(image,data.data(),header,skipMetaData);
     }
 
-    void ImageSerializer::deserialize(const icl8u *data, ImgBase **dst) {
+    void ImageSerializer::deserialize(const icl8u *data, ImgBase **dst){
       ICLASSERT_THROW(dst,ICLException(str(__FUNCTION__)+": destination ImgBase** was null"));
       ICLASSERT_THROW(dst,ICLException(str(__FUNCTION__)+": source data pinter was null"));
 
@@ -163,12 +163,12 @@ namespace icl{
       }
     }
 
-    int ImageSerializer::estimateSerializedSize(const ImgBase *image, bool skipMetaData) {
+    int ImageSerializer::estimateSerializedSize(const ImgBase *image, bool skipMetaData){
       ICLASSERT_THROW(image,ICLException(str(__FUNCTION__)+": image was null"));
       return getHeaderSize() + estimateImageDataSize(image) + sizeof(icl32s) + (skipMetaData ? 0 : image->getMetaData().length());
     }
 
-    Time ImageSerializer::deserializeTimeStamp(const icl8u *data) {
+    Time ImageSerializer::deserializeTimeStamp(const icl8u *data){
       return Time(*(const int64_t*)(data+9*sizeof(icl32s)));
     }
   } // namespace core

--- a/ICLCore/src/ICLCore/ImageSerializer.h
+++ b/ICLCore/src/ICLCore/ImageSerializer.h
@@ -71,29 +71,29 @@ namespace icl{
       static int getHeaderSize();
 
       /// estimates the size for the image data of an serialized image
-      static int estimateImageDataSize(const ImgBase *image) ;
+      static int estimateImageDataSize(const ImgBase *image);
 
       /// estimates the full size of an serialized image
-      static int estimateSerializedSize(const ImgBase *image, bool skipMetaData=false) ;
+      static int estimateSerializedSize(const ImgBase *image, bool skipMetaData=false);
 
       /// creates an image header from given image
-      static ImageHeader createHeader(const ImgBase *image) ;
+      static ImageHeader createHeader(const ImgBase *image);
 
       /// serializes an image into given destination data-points (which has to be long enough)
       static void serialize(const ImgBase *image, icl8u *dst,
                             const ImageHeader &header=ImageHeader(),
-                            bool skipMetaData=false) ;
+                            bool skipMetaData=false);
 
       /// serializes an image into given vector (the vector size is adapted automatically)
       static void serialize(const ImgBase *image, std::vector<icl8u> &data,
                             const ImageHeader &header=ImageHeader(),
-                            bool skipMetaData=false) ;
+                            bool skipMetaData=false);
 
       /// deserializes an image (and optionally also the meta-data) from given icl8u data block
-      static void deserialize(const icl8u *data, ImgBase **dst) ;
+      static void deserialize(const icl8u *data, ImgBase **dst);
 
       /// extracts only an images TimeStamp from it's serialized form
-      static utils::Time deserializeTimeStamp(const icl8u *data) ;
+      static utils::Time deserializeTimeStamp(const icl8u *data);
 
     };
   } // namespace core

--- a/ICLCore/src/ICLCore/Img.cpp
+++ b/ICLCore/src/ICLCore/Img.cpp
@@ -187,7 +187,7 @@ namespace icl {
                    const DynMatrix<Type> &c2,
                    const DynMatrix<Type> &c3,
                    const DynMatrix<Type> &c4,
-                   const DynMatrix<Type> &c5) :
+                   const DynMatrix<Type> &c5):
       ImgBase(icl::core::getDepth<Type>(),ImgParams(Size(c1.cols(),c1.rows()),get_channel_count(c1,c2,c3,c4,c5))){
 
       if(c1.isNull()) return;

--- a/ICLCore/src/ICLCore/Img.h
+++ b/ICLCore/src/ICLCore/Img.h
@@ -279,7 +279,7 @@ namespace icl {
           const math::DynMatrix<Type> &c2=math::DynMatrix<Type>(),
           const math::DynMatrix<Type> &c3=math::DynMatrix<Type>(),
           const math::DynMatrix<Type> &c4=math::DynMatrix<Type>(),
-          const math::DynMatrix<Type> &c5=math::DynMatrix<Type>()) ;
+          const math::DynMatrix<Type> &c5=math::DynMatrix<Type>());
 
 
       /// Destructor
@@ -433,20 +433,18 @@ namespace icl {
       /** @{ @name extractChannel functions */
       /* {{{ open  */
 
-      /*inline <Type> operator[](int channel) {
+      /*inline <Type> operator[](int channel){
         return DynMatrix<Type>(getWidth(),getHeight(),begin(channel),false);
       }*/
 
       /// extracts given channel as DynMatrix<Type>
       /* This function cannot be called on (0,x) or (x,0)-sized images */
-      inline math::DynMatrix<Type> extractDynMatrix(int channel)
-        {
+      inline math::DynMatrix<Type> extractDynMatrix(int channel){
         return math::DynMatrix<Type>(getWidth(),getHeight(),begin(channel),false);
       }
       /// extracts given channel as DynMatrix<Type> const
       /* This function cannot be called on (0,x) or (x,0)-sized images */
-      inline const math::DynMatrix<Type> extractDynMatrix(int channel) const
-        {
+      inline const math::DynMatrix<Type> extractDynMatrix(int channel) const{
         return math::DynMatrix<Type>(getWidth(),getHeight(),const_cast<Type*>(begin(channel)),false);
       }
 

--- a/ICLCore/src/ICLCore/OpenCV.cpp
+++ b/ICLCore/src/ICLCore/OpenCV.cpp
@@ -92,7 +92,7 @@ namespace icl{
       return *dst;
     }
 
-    ImgBase *ipl_to_img(CvArr *src,ImgBase **dst,DepthPreference e) {
+    ImgBase *ipl_to_img(CvArr *src,ImgBase **dst,DepthPreference e){
       if(!src){
         throw ICLException("Source is NULL");
       }
@@ -199,7 +199,7 @@ namespace icl{
       return dst;
     }
 
-    IplImage *img_to_ipl(const ImgBase *src, IplImage **dst,DepthPreference e) {
+    IplImage *img_to_ipl(const ImgBase *src, IplImage **dst,DepthPreference e){
       ICLASSERT_THROW(src,ICLException("Source is NULL"));
 
       if(dst && *dst && e==PREFERE_DST_DEPTH){
@@ -267,7 +267,7 @@ namespace icl{
       return dst;
     }
 
-    CvMat* img_to_cvmat(const ImgBase *src, CvMat *dst,int channel) {
+    CvMat* img_to_cvmat(const ImgBase *src, CvMat *dst,int channel){
       if(!src){
         throw ICLException("Source is NULL");
       }
@@ -332,7 +332,7 @@ namespace icl{
       return *dst;
     }
 
-    CvMat *img_to_cvmat_shallow(const ImgBase *src,CvMat *dst) {
+    CvMat *img_to_cvmat_shallow(const ImgBase *src,CvMat *dst){
       if(!src){
         throw ICLException("Source is NULL");
       }
@@ -518,7 +518,7 @@ ICL_INSTANTIATE_ALL_DEPTHS
 #undef ICL_INSTANTIATE_DEPTH
 
 
-    ::cv::Mat *img_to_mat(const ImgBase *src, ::cv::Mat *dstIn) {
+    ::cv::Mat *img_to_mat(const ImgBase *src, ::cv::Mat *dstIn){
       ICLASSERT_THROW(src && src->getChannels() > 0 && src->getChannels() <=4, ICLException("img_to_mat: invalid source image"));
       ::cv::Mat *dst = dstIn ? dstIn : new ::cv::Mat;
       dst->create(src->getHeight(), src->getWidth(), estimate_mat_type(src->getDepth(), src->getChannels()));
@@ -533,12 +533,12 @@ ICL_INSTANTIATE_ALL_DEPTHS
       return dst;
     }
 
-    void mat_to_img(const ::cv::Mat *src, ImgBase **dstIn) {
+    void mat_to_img(const ::cv::Mat *src, ImgBase **dstIn){
       ensureCompatible(dstIn, extract_depth(src), extract_size(src), extract_channels(src));
       mat_to_img(src, *dstIn);
     }
 
-    ImgBase *mat_to_img(const ::cv::Mat *src, ImgBase *dstIn) {
+    ImgBase *mat_to_img(const ::cv::Mat *src, ImgBase *dstIn){
       ICLASSERT_THROW(src, ICLException("mat_to_img: input is null"));
       ICLASSERT_THROW(src->isContinuous(), "mat_to_img: input image must be continoues");
 

--- a/ICLCore/src/ICLCore/OpenCV.h
+++ b/ICLCore/src/ICLCore/OpenCV.h
@@ -86,7 +86,7 @@ namespace icl{
         @param *src pointer to sourceimage (IplImage)
         @param **dst pointer to pointer to destinationimage (ICLimage)
         @param e depthpreference*/
-    ICLCore_API ImgBase *ipl_to_img(CvArr *src,ImgBase **dst=0,DepthPreference e=PREFERE_SRC_DEPTH) ;
+    ICLCore_API ImgBase *ipl_to_img(CvArr *src,ImgBase **dst=0,DepthPreference e=PREFERE_SRC_DEPTH);
 
     ///Convert ICLimage to OpenCV IplImage
     /**Converts ICLimage to IplImage. If dst is NULL, the sourceimagedepth
@@ -102,7 +102,7 @@ namespace icl{
         @param *src pointer to sourceimage
         @param **dst pointer to pointer to destinationmatrix
         @param channel channel to use*/
-    ICLCore_API CvMat* img_to_cvmat(const ImgBase *src, CvMat *dst = 0, int channel = 0) ;
+    ICLCore_API CvMat* img_to_cvmat(const ImgBase *src, CvMat *dst = 0, int channel = 0);
 
     ///Convert single channel ICLimage to OpenCV IplImage
     /**Converts single channel ICLimage to IplImage. Data is shared by source and destination.
@@ -119,18 +119,18 @@ namespace icl{
         Be careful when releasig (data)pointers.
         @param *src pointer to sourceimage
         @param *dst pointer to destinationmatrix (IplImage)*/
-    ICLCore_API CvMat *img_to_cvmat_shallow(const ImgBase *src, CvMat *dst = 0) ;
+    ICLCore_API CvMat *img_to_cvmat_shallow(const ImgBase *src, CvMat *dst = 0);
 
     /// converts icl image into opencv's C++ image type cv::Mat (data is deeply copied)
     /** If a destimation Mat is given, it will be set up to resemble the input images
         parameters exactly. Therefore, the data is always copied and never converted */
-    ICLCore_API ::cv::Mat *img_to_mat(const ImgBase *src, ::cv::Mat *dst=0) ;
+    ICLCore_API ::cv::Mat *img_to_mat(const ImgBase *src, ::cv::Mat *dst=0);
 
     /// converts cv::Mat to ImgBase (internally the pixel data is type-converted if needed)
-    ICLCore_API ImgBase *mat_to_img(const ::cv::Mat *src, ImgBase *dstIn=0) ;
+    ICLCore_API ImgBase *mat_to_img(const ::cv::Mat *src, ImgBase *dstIn=0);
 
     /// converts cv::Mat to ImgBase (internally the pixel data is type-converted if needed)
-    ICLCore_API void mat_to_img(const ::cv::Mat *src, ImgBase **dstIn) ;
+    ICLCore_API void mat_to_img(const ::cv::Mat *src, ImgBase **dstIn);
 
 
     /// Very simply wrapper about the opencv C++ matrix type cv::Mat

--- a/ICLCore/src/ICLCore/PixelRef.h
+++ b/ICLCore/src/ICLCore/PixelRef.h
@@ -148,7 +148,7 @@ namespace icl{
       /// assigns a ranges contents to the pixel data
       /** An exception is only thrown of the given range is too short*/
       template<class ForwardIterator>
-      inline void setFromRange(ForwardIterator begin, ForwardIterator end) {
+      inline void setFromRange(ForwardIterator begin, ForwardIterator end){
         for(unsigned int i=0;i<m_data.size();++i,++begin){
           if(begin == end) throw utils::ICLException("Range is longer then channel count");
           *m_data[i] = *begin;
@@ -156,13 +156,13 @@ namespace icl{
       }
 
       /// references a single element (safe)
-      T &operator[](unsigned int channel) {
+      T &operator[](unsigned int channel){
         ICLASSERT_THROW(channel < m_data.size(),utils::ICLException("invalid channel index"));
         return *m_data[channel];
       }
 
       /// references a single element (const) (safe)
-      const T &operator[](unsigned int channel) const {
+      const T &operator[](unsigned int channel) const{
         ICLASSERT_THROW(channel < m_data.size(),utils::ICLException("invalid channel index"));
         return *m_data[channel];
       }

--- a/ICLCore/src/ICLCore/PseudoColorConverter.cpp
+++ b/ICLCore/src/ICLCore/PseudoColorConverter.cpp
@@ -120,7 +120,7 @@ namespace icl{
         }
       }
 
-      void custom(const std::vector<Stop> &stopsIn, int maxValue) {
+      void custom(const std::vector<Stop> &stopsIn, int maxValue){
         maxVal = maxValue;
         if(!stopsIn.size()) throw ICLException("PseudoColorConverter: no stops found");
         mode = PseudoColorConverter::Custom;
@@ -152,12 +152,12 @@ namespace icl{
     }
 
       /// creates instance with custom mode
-    PseudoColorConverter::PseudoColorConverter(const std::vector<Stop> &stops, int maxValue) {
+    PseudoColorConverter::PseudoColorConverter(const std::vector<Stop> &stops, int maxValue):m_data(new Data){
       m_data->custom(stops,maxValue);
     }
 
       /// sets the mode
-    void PseudoColorConverter::setColorTable(ColorTable t, const std::vector<Stop> &stops, int maxValue) {
+    void PseudoColorConverter::setColorTable(ColorTable t, const std::vector<Stop> &stops, int maxValue){
       if(t == Custom){
         m_data->custom(stops,maxValue);
       }else{
@@ -166,7 +166,7 @@ namespace icl{
     }
 
       /// create a speudo color image from given source image
-    void PseudoColorConverter::apply(const ImgBase *src, ImgBase **dst) {
+    void PseudoColorConverter::apply(const ImgBase *src, ImgBase **dst){
       ICLASSERT_THROW(src,ICLException(str(__FUNCTION__)+": src image was NULL"));
       ICLASSERT_THROW(dst,ICLException(str(__FUNCTION__)+": destination image was NULL"));
       ICLASSERT_THROW(src->getChannels() == 1, ICLException(str(__FUNCTION__)+": source image has more than one channel"));

--- a/ICLCore/src/ICLCore/PseudoColorConverter.h
+++ b/ICLCore/src/ICLCore/PseudoColorConverter.h
@@ -62,7 +62,7 @@ namespace icl{
 
       /// creates instance with custom mode
       /** @see setColorTable */
-      PseudoColorConverter(const std::vector<Stop> &stops, int maxValue=255) ;
+      PseudoColorConverter(const std::vector<Stop> &stops, int maxValue=255);
 
       /// sets the color table mode
       /** if mode is default, stops must be empty
@@ -77,11 +77,10 @@ namespace icl{
           all pixels are set to the given color. However, there are simpler functions that
           have the same result and are less complex (like Img<T>::clear(channelIndx,color))
       */
-      void setColorTable(ColorTable t, const std::vector<Stop> &stops=std::vector<Stop>(), int maxValue=255)
-        ;
+      void setColorTable(ColorTable t, const std::vector<Stop> &stops=std::vector<Stop>(), int maxValue=255);
 
       /// create a speudo color image from given source image
-      void apply(const ImgBase *src, ImgBase **dst) ;
+      void apply(const ImgBase *src, ImgBase **dst);
 
       /// create a speudo color image from given source image
       void apply(const Img8u &src, Img8u &dst);

--- a/ICLFilter/src/ICLFilter/BilateralFilterOp.cpp
+++ b/ICLFilter/src/ICLFilter/BilateralFilterOp.cpp
@@ -575,7 +575,7 @@ void BilateralFilterOp::init(Mode mode, Method method) {
 BilateralFilterOp::~BilateralFilterOp() {
 }
 
-void BilateralFilterOp::apply(const core::ImgBase *in, core::ImgBase **out) throw() {
+void BilateralFilterOp::apply(const core::ImgBase *in, core::ImgBase **out) noexcept {
 	if (_method == GAUSS)
 		impl->applyGauss(in,out,radius,sigma_s,sigma_r,use_lab);
 	else if (_method == KUWAHARA)

--- a/ICLFilter/src/ICLFilter/BilateralFilterOp.h
+++ b/ICLFilter/src/ICLFilter/BilateralFilterOp.h
@@ -77,7 +77,7 @@ public:
 	 * @param in Image to filter.
 	 * @param out Filter result (must be of the same size and format)
 	 */
-	void apply(const core::ImgBase *in, core::ImgBase **out) throw();
+	void apply(const core::ImgBase *in, core::ImgBase **out) noexcept;
 
 	/// Sets the kernel radius
 	void setRadius(int radius) { this->radius = radius; }

--- a/ICLFilter/src/ICLFilter/ColorSegmentationOp.cpp
+++ b/ICLFilter/src/ICLFilter/ColorSegmentationOp.cpp
@@ -335,7 +335,7 @@ namespace icl{
       }
     }
 
-    ColorSegmentationOp::ColorSegmentationOp(icl8u c0shift, icl8u c1shift, icl8u c2shift, format fmt)  :
+    ColorSegmentationOp::ColorSegmentationOp(icl8u c0shift, icl8u c1shift, icl8u c2shift, format fmt):
       m_segFormat(fmt),m_lut(new LUT3D(0,0,0)){
       ICLASSERT_THROW(getChannelsOfFormat(fmt) == 3,ICLException("Construktor ColorSegmentationOp: format must be a 3-channel format"));
       setSegmentationShifts(c0shift,c1shift,c2shift);
@@ -418,7 +418,7 @@ namespace icl{
       return m_segPreview;
     }
 
-    void ColorSegmentationOp::setSegmentationFormat(format fmt) {
+    void ColorSegmentationOp::setSegmentationFormat(format fmt){
       ICLASSERT_THROW(getChannelsOfFormat(fmt) == 3, ICLException("ColorSegmentationOp::setSegmentationFormat: Segmentation format must have 3 channels"));
       m_segFormat = fmt;
     }
@@ -456,7 +456,7 @@ namespace icl{
       }
     }
 
-    void ColorSegmentationOp::lutEntry(format fmt, int a, int b, int c, int rA, int rB, int rC, icl8u value) {
+    void ColorSegmentationOp::lutEntry(format fmt, int a, int b, int c, int rA, int rB, int rC, icl8u value){
       if(fmt == m_segFormat) lutEntry(a,b,c,rA,rB,rC,value);
       ICLASSERT_THROW(getChannelsOfFormat(fmt) == 3, ICLException("ColorSegmentationOp::lutEntry format must have 3 channels"));
       Img8u src(Size(1,1),fmt),dst(Size(1,1),m_segFormat);

--- a/ICLFilter/src/ICLFilter/ColorSegmentationOp.h
+++ b/ICLFilter/src/ICLFilter/ColorSegmentationOp.h
@@ -131,7 +131,7 @@ namespace icl{
           @param c2shift number of least significant bits that are removed from channel2
           @param fmt internally used segmentation format (needs to have 3 channels)
           */
-      ColorSegmentationOp(icl8u c0shift=2, icl8u c1shift=2, icl8u c2shift=2,core::format fmt=core::formatYUV) ;
+      ColorSegmentationOp(icl8u c0shift=2, icl8u c1shift=2, icl8u c2shift=2,core::format fmt=core::formatYUV);
 
       /// Destructor
       ~ColorSegmentationOp();
@@ -152,7 +152,7 @@ namespace icl{
       void setSegmentationShifts(icl8u c0shift, icl8u c1shift, icl8u c2shift);
 
       /// sets the internally used segmentation format
-      void setSegmentationFormat(core::format fmt) ;
+      void setSegmentationFormat(core::format fmt);
 
       /// returns the pointer to the 3 internally used segmentation shifts
       const icl8u *getSegmentationShifts() const { return m_bitShifts; }
@@ -170,7 +170,7 @@ namespace icl{
       void lutEntry(icl8u a, icl8u b, icl8u c, icl8u rA, icl8u rB, icl8u rC, icl8u value);
 
       /// given a,b and c in format fmt, this function fills the LUT within a sub-volume with given radii
-      void lutEntry(core::format fmt, int a, int b, int c, int rA, int rB, int rC, icl8u value) ;
+      void lutEntry(core::format fmt, int a, int b, int c, int rA, int rB, int rC, icl8u value);
 
       /// loads the segmentation LUT only (no other parameters)
       void load(const std::string &filename);

--- a/ICLFilter/src/ICLFilter/ConvolutionKernel.cpp
+++ b/ICLFilter/src/ICLFilter/ConvolutionKernel.cpp
@@ -124,7 +124,7 @@ namespace icl{
       }
     }
 
-    ConvolutionKernel::ConvolutionKernel(int *data, const Size &size,int factor, bool deepCopy) :
+    ConvolutionKernel::ConvolutionKernel(int *data, const Size &size,int factor, bool deepCopy):
       size(size),fdata(0),idata(0),factor(factor),isnull(false),owned(deepCopy),ft(custom){
       ICLASSERT_THROW(getDim() > 0,InvalidSizeException(__FUNCTION__));
       if(deepCopy){
@@ -134,7 +134,7 @@ namespace icl{
       }
       isnull = !idata;
     }
-    ConvolutionKernel::ConvolutionKernel(float *data, const Size &size, bool deepCopy) :
+    ConvolutionKernel::ConvolutionKernel(float *data, const Size &size, bool deepCopy):
       size(size),fdata(0),idata(0),factor(1),isnull(false),owned(deepCopy),ft(custom){
       ICLASSERT_THROW(getDim() > 0,InvalidSizeException(__FUNCTION__));
       if(deepCopy){

--- a/ICLFilter/src/ICLFilter/ConvolutionKernel.h
+++ b/ICLFilter/src/ICLFilter/ConvolutionKernel.h
@@ -141,10 +141,10 @@ namespace icl{
           // where *(x,y)* is a convolution at location (x,y)
           </code>
       */
-      ConvolutionKernel(int *data, const utils::Size &size,int factor=1, bool deepCopy=true) ;
+      ConvolutionKernel(int *data, const utils::Size &size,int factor=1, bool deepCopy=true);
 
       /// create a float valued kernel
-      ConvolutionKernel(float *data, const utils::Size &size, bool deepCopy=true) ;
+      ConvolutionKernel(float *data, const utils::Size &size, bool deepCopy=true);
 
       /// create a fixed kernel (optionally as float kernel)
       ConvolutionKernel(fixedType t, bool useFloats=false);

--- a/ICLFilter/src/ICLFilter/ImageRectification.cpp
+++ b/ICLFilter/src/ICLFilter/ImageRectification.cpp
@@ -47,7 +47,7 @@ namespace icl{
       return buffer;
     }
 
-    static void convexity_check_and_sorting(Point32f ps[4]) {
+    static void convexity_check_and_sorting(Point32f ps[4]){
       std::vector<Point32f> hull = convexHull(std::vector<Point32f>(ps,ps+4));
       // first and last points are doubled
       if(hull.size() != 5) throw ICLException("ImageRectification<T>::apply: given points do not define a convex quadrangle");
@@ -87,7 +87,7 @@ namespace icl{
     static const Homography2D create_and_check_homography(bool validateAndSortPoints,const Point32f psin[4], const Img<T> &src,
                                                           const Size &resultSize, FixedMatrix<float,3,3> *hom,
                                                           FixedMatrix<float,2,2> *Q, FixedMatrix<float,2,2> *R,float maxTilt,
-                                                          Img<T> &buffer, bool advanedAlgorithm) {
+                                                          Img<T> &buffer, bool advanedAlgorithm){
       Point32f ps[4]={psin[0],psin[1],psin[2],psin[3]};
       // we need this check, because otherwise, we cannot check whether
       // the image boarders are intersected by checking the four corners only

--- a/ICLFilter/src/ICLFilter/UnaryCompareOp.h
+++ b/ICLFilter/src/ICLFilter/UnaryCompareOp.h
@@ -75,7 +75,7 @@ namespace icl {
           - UnaryCompareOp::eq -> "=="
           - UnaryCompareOp::eqt -> "~="
       */
-      static optype translate_op_type(const std::string &stringVersion) {
+      static optype translate_op_type(const std::string &stringVersion){
         if(stringVersion == "<") return UnaryCompareOp::lt;
         if(stringVersion == ">") return UnaryCompareOp::gt;
         if(stringVersion == "<=") return UnaryCompareOp::lteq;

--- a/ICLFilter/src/ICLFilter/UnaryOp.cpp
+++ b/ICLFilter/src/ICLFilter/UnaryOp.cpp
@@ -368,7 +368,7 @@ namespace icl{
 
     }
 
-    UnaryOp *UnaryOp::fromString(const std::string &definition) {
+    UnaryOp *UnaryOp::fromString(const std::string &definition){
       unary_op_from_string::static_init();
       //bool hasParams = true;
       if(!definition.size()) throw ICLException(str(__FUNCTION__)+": empty defintion string");
@@ -392,7 +392,7 @@ namespace icl{
       return op;
     }
 
-    std::string UnaryOp::getFromStringSyntax(const std::string &opSpecifier) {
+    std::string UnaryOp::getFromStringSyntax(const std::string &opSpecifier){
       unary_op_from_string::static_init();
       std::map<std::string,unary_op_from_string::Creator>::iterator it=unary_op_from_string::CREATORS.find(opSpecifier);
       if(it == unary_op_from_string::CREATORS.end()) throw ICLException(str(__FUNCTION__)+": no op found for given specifier ["+opSpecifier+"]");
@@ -410,7 +410,7 @@ namespace icl{
       return v;
     }
 
-    void UnaryOp::applyFromString(const std::string &definition, const ImgBase *src, ImgBase **dst) {
+    void UnaryOp::applyFromString(const std::string &definition, const ImgBase *src, ImgBase **dst){
       unary_op_from_string::static_init();
       UnaryOp *op = fromString(definition);
       if(!op) throw ICLException(str(__FUNCTION__)+": no op found for given definition string ["+definition+"]");
@@ -418,7 +418,7 @@ namespace icl{
       delete op;
     }
 
-    void UnaryOp::setPropertyValue(const std::string &propertyName, const Any &value) {
+    void UnaryOp::setPropertyValue(const std::string &propertyName, const Any &value){
       if(propertyName == "UnaryOp.clip to ROI") setClipToROI(value == "on");
       else if(propertyName == "UnaryOp.check only") setCheckOnly(value == "on");
       Configurable::setPropertyValue(propertyName,value);

--- a/ICLFilter/src/ICLFilter/UnaryOp.h
+++ b/ICLFilter/src/ICLFilter/UnaryOp.h
@@ -129,7 +129,7 @@ namespace icl{
 
 
       /// sets value of a property (always call call_callbacks(propertyName) or Configurable::setPropertyValue)
-      virtual void setPropertyValue(const std::string &propertyName, const utils::Any &value) ;
+      virtual void setPropertyValue(const std::string &propertyName, const utils::Any &value);
 
       /// Creates a UnaryOp instance from given string definition
       /** Supported definitions have the followin syntax:
@@ -144,11 +144,11 @@ namespace icl{
           Each specific parameter list's syntax is accessible using the static getFromStringSyntax function.
 
       */
-      static UnaryOp *fromString(const std::string &definition) ;
+      static UnaryOp *fromString(const std::string &definition);
 
       /// gives a string syntax description for given opSpecifier
       /** opSpecifier must be a member of the list returned by the static function listFromStringOps */
-      static std::string getFromStringSyntax(const std::string &opSpecifier) ;
+      static std::string getFromStringSyntax(const std::string &opSpecifier);
 
       /// returns a list of all supported OP_SPEC values for the fromString function
       static std::vector<std::string> listFromStringOps();
@@ -156,7 +156,7 @@ namespace icl{
       /// creates, applies and releases a UnaryOp defined by given definition string
       static void applyFromString(const std::string &definition,
                                   const core::ImgBase *src,
-                                  core::ImgBase **dst) ;
+                                  core::ImgBase **dst);
 
       protected:
       bool prepare (core::ImgBase **ppoDst, core::depth eDepth, const utils::Size &imgSize,

--- a/ICLGeom/src/ICLGeom/Camera.cpp
+++ b/ICLGeom/src/ICLGeom/Camera.cpp
@@ -317,16 +317,14 @@ namespace icl {
 
     Camera Camera::calibrate_extrinsic(const std::vector<Vec> &Xws, const std::vector<utils::Point32f> &xis,
                                        const Camera &intrinsicCamValue, const RenderParams &renderParams,
-                                       bool performLMAbasedOptimiziation)
-       {
+                                       bool performLMAbasedOptimiziation) {
       return calibrate_extrinsic(Xws, xis, intrinsicCamValue.getProjectionMatrix(), renderParams, performLMAbasedOptimiziation);
     }
 
 
     Camera Camera::calibrate_extrinsic(const std::vector<Vec> &Xws, const std::vector<utils::Point32f> &xis,
                                        const Mat &camIntrinsicProjectionMatrix, const RenderParams &renderParams,
-                                       bool performLMAbasedOptimiziation)
-       {
+                                       bool performLMAbasedOptimiziation) {
       const Mat &k = camIntrinsicProjectionMatrix;
       return calibrate_extrinsic(Xws, xis, k(0,0), k(1,1), k(1,0), k(2,0), k(2,1), renderParams, performLMAbasedOptimiziation);
     }
@@ -338,8 +336,7 @@ namespace icl {
 
     Camera Camera::calibrate_extrinsic(std::vector<Vec> Xws, std::vector<utils::Point32f> xis,
                                        float fx, float fy, float s, float px ,float py,
-                                       const RenderParams &renderParams, bool performLMAbasedOptimiziation)
-     {
+                                       const RenderParams &renderParams, bool performLMAbasedOptimiziation) {
       checkAndFixPoints(Xws,xis);
 
       int n = (int)Xws.size();
@@ -474,8 +471,7 @@ namespace icl {
     Camera Camera::calibrate_pinv(std::vector<Vec> Xws,
                                   std::vector<Point32f> xis,
                                   float focalLength,
-                                  bool performLMAbasedOptimiziation)
-       {
+                                  bool performLMAbasedOptimiziation) {
       // TODO: normalize points
       checkAndFixPoints(Xws,xis);
 
@@ -512,8 +508,7 @@ namespace icl {
     Camera Camera::calibrate(std::vector<Vec> Xws,
                              std::vector<Point32f> xis,
                              float focalLength,
-                             bool performLMAbasedOptimiziation)
-       {
+                             bool performLMAbasedOptimiziation) {
 
       //  #ifndef ICL_HAVE_MKL
       // 	return calibrate_pinv(Xws,xis,focalLength);
@@ -554,7 +549,7 @@ namespace icl {
       }
     }
 
-    void Camera::checkAndFixPoints(std::vector<Vec> &Xws, std::vector<Point32f> &xis)  {
+    void Camera::checkAndFixPoints(std::vector<Vec> &Xws, std::vector<Point32f> &xis) {
       if(Xws.size() > xis.size()){
         ERROR_LOG("got more world points than image points (erasing additional world points)");
         Xws.resize(xis.size());
@@ -670,18 +665,18 @@ namespace icl {
     }
 
     /// istream operator parses a camera from an XML-string
-    std::istream &operator>>(std::istream &is, Camera &cam)  {
+    std::istream &operator>>(std::istream &is, Camera &cam) {
       cam = Camera(is,"config.");
       return is;
     }
 
-    Camera::Camera(const std::string &filename, const std::string &prefix) {
+    Camera::Camera(const std::string &filename, const std::string &prefix){
       if(!File(filename).exists()) throw ParseException("Camera(filename) given file '" + filename + "' does not exist!");
       std::ifstream is(filename.c_str());
       load_camera_from_stream(is,prefix,*this);
     }
 
-    Camera::Camera(std::istream &is, const std::string &prefix) {
+    Camera::Camera(std::istream &is, const std::string &prefix){
       load_camera_from_stream(is,prefix,*this);
     }
 
@@ -723,14 +718,14 @@ namespace icl {
       return ViewRay(m_pos, Xw-m_pos);
     }
 
-    Vec Camera::getIntersection(const ViewRay &v, const PlaneEquation &plane)  {
+    Vec Camera::getIntersection(const ViewRay &v, const PlaneEquation &plane) {
       float denom = sprod_3(v.direction, plane.normal);
       if (fabs(denom) < 1e-6) throw ICLException("no intersection -> plane normal is perdendicular to view-ray direction");
       float lambda = -sprod_3(v.offset-plane.offset,plane.normal) / denom;
       return v(lambda);
     }
 
-    Vec Camera::estimate3DPosition(const Point32f &pixel, const PlaneEquation &plane) const  {
+    Vec Camera::estimate3DPosition(const Point32f &pixel, const PlaneEquation &plane) const {
       return getIntersection(getViewRay(pixel),plane);
     }
 
@@ -746,7 +741,7 @@ namespace icl {
     */
 
     static Vec estimate_3D_internal(const std::vector<Camera*> cams,
-                                    const std::vector<Point32f> &ps) {
+                                    const std::vector<Point32f> &ps){
       // {{{ open
       int K = (int)cams.size();
       ICLASSERT_THROW(K > 1,ICLException("Camera::estimate_3D_internal: 3D point estimation needs at least 2 views"));
@@ -788,7 +783,7 @@ namespace icl {
 
     Vec Camera::estimate_3D(const std::vector<Camera*> cams,
                             const std::vector<Point32f> &UVs,
-                            bool removeInvalidPoints) {
+                            bool removeInvalidPoints){
       // {{{ open
       ICLASSERT_THROW(cams.size() == UVs.size(),ICLException("Camera::estimate_3D: given camera count and point count differs"));
       if(removeInvalidPoints){
@@ -911,7 +906,7 @@ namespace icl {
       setPrincipalPointOffset(newPrincipalPointOffset);
     }
 
-    Camera Camera::create_camera_from_calibration_or_udist_file(const std::string &filename) {
+    Camera Camera::create_camera_from_calibration_or_udist_file(const std::string &filename){
       SmartPtr<io::ImageUndistortion> udist;
       try{
         udist = new io::ImageUndistortion(filename);

--- a/ICLGeom/src/ICLGeom/Camera.h
+++ b/ICLGeom/src/ICLGeom/Camera.h
@@ -174,13 +174,13 @@ namespace icl {
           @param prefix valid prefix that determines wheret to find the camera within the
                  given config file (note, that this prefix must end with '.')
           */
-      Camera(const std::string &filename, const std::string &prefix="config.")  ;
+      Camera(const std::string &filename, const std::string &prefix="config.");
       /// loads a camera from given input stream
       /** @param configDataStream stream object to read and interpret input file name of valid configuration file (in ICL's ConfigFile core::format)
           @param prefix valid prefix that determines where to find the camera within the
                  given config file (note, that this prefix must end with '.')
           */
-      Camera(std::istream &configDataStream, const std::string &prefix="config.")  ;
+      Camera(std::istream &configDataStream, const std::string &prefix="config.");
 
 
       /** @} @{ @name static creation functions */
@@ -196,29 +196,25 @@ namespace icl {
           which an SVD is used.
       */
       static Camera calibrate(std::vector<Vec> Xws, std::vector<utils::Point32f> xis, float focalLength=1,
-                              bool performLMAOptimization=true)
-        ;
+                              bool performLMAOptimization=true);
 
       /// Uses the passed world point -- image point references to estimate the projection parameters.
       /** Same as the method calibrate, but using a pseudoinvers instead of the SVD for the estimation.
           This method is less stable and less exact. */
       static Camera calibrate_pinv(std::vector<Vec> Xws, std::vector<utils::Point32f> xis, float focalLength=1,
-                                   bool performLMAOptimization=true)
-        ;
+                                   bool performLMAOptimization=true);
 
       /// performs extrinsic camera calibration using a given set of 2D-3D correspondences and the given intrinsic camera calibration data
       /** @see Camera::calibrate_extrinsic((std::vector<Vec>,std::vector<utils::Point32f>,float,float,float,float,float) */
       static Camera calibrate_extrinsic(const std::vector<Vec> &Xws, const std::vector<utils::Point32f> &xis,
                                         const Camera &intrinsicCamValue, const RenderParams &renderParams=RenderParams(),
-                                        bool performLMAOptimization=true)
-      ;
+                                        bool performLMAOptimization=true);
 
       /// performs extrinsic camera calibration using a given set of 2D-3D correspondences and the given intrinsic camera calibration data
       /** @see Camera::calibrate_extrinsic((std::vector<Vec>,std::vector<utils::Point32f>,float,float,float,float,float) */
       static Camera calibrate_extrinsic(const std::vector<Vec> &Xws, const std::vector<utils::Point32f> &xis,
                                         const Mat &camIntrinsicProjectionMatrix, const RenderParams &renderParams=RenderParams(),
-                                        bool performLMAOptimization=true)
-      ;
+                                        bool performLMAOptimization=true);
 
       /// performs extrinsic camera calibration using a given set of 2D-3D correspondences and the given intrinsic camera calibration data
       /** In many cases, when camera calibration is performed in a realy scene, it is quite difficult to place the calibration
@@ -321,8 +317,7 @@ namespace icl {
       static Camera calibrate_extrinsic(std::vector<Vec> Xws, std::vector<utils::Point32f> xis,
                                         float fx, float fy, float s, float px ,float py,
                                         const RenderParams &renderParams=RenderParams(),
-                                        bool performLMAOptimization=true)
-      ;
+                                        bool performLMAOptimization=true);
 
       /// performs a non-linear LMA-based optimization to improve camera calibration results
       static Camera optimize_camera_calibration_lma(const std::vector<Vec> &Xws,
@@ -368,7 +363,7 @@ namespace icl {
       ViewRay getViewRay(const Vec &Xw) const;
 
       /// returns estimated 3D point for given pixel and plane equation
-      Vec estimate3DPosition(const utils::Point32f &pixel, const PlaneEquation &plane) const ;
+      Vec estimate3DPosition(const utils::Point32f &pixel, const PlaneEquation &plane) const;
       /// calculates the intersection point between this view ray and a given plane
       /** Throws an utils::ICLException in case of parallel plane and line
           A ViewRay is defined by  \f$V: \mbox{offset} + \lambda \cdot \mbox{direction} \f$
@@ -380,7 +375,7 @@ namespace icl {
           and .. obviously, we get no intersection if direction is parallel to planeNormal
       */
       static Vec getIntersection(const ViewRay &v,
-                                 const PlaneEquation &plane) ;
+                                 const PlaneEquation &plane);
 
       /** @} @{ @name complex setter and getter functions */
 
@@ -576,7 +571,7 @@ namespace icl {
       */
       static Vec estimate_3D(const std::vector<Camera*> cams,
                              const std::vector<utils::Point32f> &UVs,
-                             bool removeInvalidPoints=false) ;
+                             bool removeInvalidPoints=false);
 
       /// estimate world frame pose of object specified by given object points
       Mat estimatePose(const std::vector<Vec> &objectCoords,
@@ -597,7 +592,7 @@ namespace icl {
           defautl created Camera instance. The undistortion file must use the model
           "MatlabModel5Params". The given resolution is not used if the given
           file is a standard camera-calibration file */
-      static Camera create_camera_from_calibration_or_udist_file(const std::string &filename) ;
+      static Camera create_camera_from_calibration_or_udist_file(const std::string &filename);
 
       protected:
       static Mat createTransformationMatrix(const Vec &norm, const Vec &up, const Vec &pos);
@@ -624,8 +619,7 @@ namespace icl {
       ////////////////////////////////////////////////////////////////////////////
 
       /// internally used utility function
-      static void checkAndFixPoints(std::vector<Vec> &worldPoints, std::vector<utils::Point32f> &imagePoints)
-        ;
+      static void checkAndFixPoints(std::vector<Vec> &worldPoints, std::vector<utils::Point32f> &imagePoints);
       /// intenal helper function
       static void load_camera_from_stream(std::istream &is,
                                           const std::string &prefix,
@@ -636,7 +630,7 @@ namespace icl {
     ICLGeom_API std::ostream &operator<<(std::ostream &os, const Camera &cam);
 
     /// istream operator parses a camera from an XML-string
-    ICLGeom_API std::istream &operator>>(std::istream &is, Camera &cam) ;
+    ICLGeom_API std::istream &operator>>(std::istream &is, Camera &cam);
 
   } // namespace geom
 } // namespace icl

--- a/ICLGeom/src/ICLGeom/DepthCameraPointCloudGrabber.cpp
+++ b/ICLGeom/src/ICLGeom/DepthCameraPointCloudGrabber.cpp
@@ -189,8 +189,7 @@ namespace icl{
       m_data->blurTool = new BlurTool;
     }
 
-    void DepthCameraPointCloudGrabber::reinit(const std::string &description)
-      {
+    void DepthCameraPointCloudGrabber::reinit(const std::string &description){
       std::vector<std::string> ts = tok(description,"@");
       std::string newDCam, newCCam;
       for(size_t i=0;i<ts.size();++i){
@@ -218,17 +217,16 @@ namespace icl{
       }
     }
 
-    Camera DepthCameraPointCloudGrabber::getDepthCamera() const {
+    Camera DepthCameraPointCloudGrabber::getDepthCamera() const{
       return m_data->creator.getDepthCamera();
     }
 
-    Camera DepthCameraPointCloudGrabber::getColorCamera() const {
+    Camera DepthCameraPointCloudGrabber::getColorCamera() const{
       return m_data->creator.getColorCamera();
     }
 
 
-    void DepthCameraPointCloudGrabber::setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T)
-      {
+    void DepthCameraPointCloudGrabber::setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T){
       Camera dCam = getDepthCamera();
       Mat Tdi = dCam.getCSTransformationMatrix();
 
@@ -358,7 +356,7 @@ namespace icl{
       return *m_data->lastDepthImage;
     }
 
-    const Img8u &DepthCameraPointCloudGrabber::getLastColorImage() const {
+    const Img8u &DepthCameraPointCloudGrabber::getLastColorImage() const{
       if(!m_data->lastColorImage){
         throw ICLException("DepthCameraPointCloudGrabber::getLastColorImage(): internal color image was null (either"
                            " no color grabber is availalble, or grab(dst) was not called before)");
@@ -382,7 +380,7 @@ namespace icl{
       return m_data->creator;
     }
 
-    RGBDMapping DepthCameraPointCloudGrabber::getMapping() const {
+    RGBDMapping DepthCameraPointCloudGrabber::getMapping() const{
       return getCreator().getMapping();
     }
 

--- a/ICLGeom/src/ICLGeom/DepthCameraPointCloudGrabber.h
+++ b/ICLGeom/src/ICLGeom/DepthCameraPointCloudGrabber.h
@@ -93,7 +93,7 @@ namespace icl{
       /// returns the last grabbed color image
       /** Throws an exception if no color camera or not valid color camera device
           type and ID were passed. */
-      const core::Img8u &getLastColorImage() const ;
+      const core::Img8u &getLastColorImage() const;
 
       /// creates the defautl VGA core::depth camera
       static const Camera &get_default_depth_cam();
@@ -126,12 +126,12 @@ namespace icl{
 
       /// returns the internal RGBDMapping
       /** only if both color- and depth camera is available */
-      RGBDMapping getMapping() const ;
+      RGBDMapping getMapping() const;
 
       /// reinitisize the backend (here, only new camera parameters can be given)
       /** The syntax is @dcam=depth-cam-filename@ccam=color-cam-filename.
           It is also possible to pass only one of the @ tokens. */
-      void reinit(const std::string &description) ;
+      void reinit(const std::string &description);
 
       /// returns the last grabbed point cloud's underlying depth image
       virtual const core::Img32f *getDepthImage() const;
@@ -140,18 +140,18 @@ namespace icl{
       virtual const core::Img8u *getColorImage() const;
 
       /// returns current depth camera
-      virtual Camera getDepthCamera() const ;
+      virtual Camera getDepthCamera() const;
 
       /// returns current color camera
       /** If no color camera was given, an exception is thrown */
-      virtual Camera getColorCamera() const ;
+      virtual Camera getColorCamera() const;
 
       /// sets up the cameras world frame
       /** Internally, this will set the depth camera's world frame to T.
           If a color camera is given, it will be also moved so that the
           relative transform between the depth camera and the color camera
           remains the same. Otherwise, the RGBD-mapping would become broken */
-      virtual void setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T) ;
+      virtual void setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T);
 
     };
   } // namespace geom

--- a/ICLGeom/src/ICLGeom/GenericPointCloudGrabber.cpp
+++ b/ICLGeom/src/ICLGeom/GenericPointCloudGrabber.cpp
@@ -64,28 +64,28 @@ namespace icl{
       delete m_data;
     }
 
-    void GenericPointCloudGrabber::reinit(const std::string &description) {
+    void GenericPointCloudGrabber::reinit(const std::string &description){
       if(isNull()){
         throw ICLException("cannot re-initialize GenericPointCloudGrabber: instance null!");
       }
       m_data->impl->reinit(description);
     }
 
-    Camera GenericPointCloudGrabber::getDepthCamera() const {
+    Camera GenericPointCloudGrabber::getDepthCamera() const{
       if(isNull()){
         throw ICLException("GenericPointCloudGrabber::getDepthCamera(): called on null instance");
       }
       return m_data->impl->getDepthCamera();
     }
 
-    Camera GenericPointCloudGrabber::getColorCamera() const {
+    Camera GenericPointCloudGrabber::getColorCamera() const{
       if(isNull()){
         throw ICLException("GenericPointCloudGrabber::getColorCamera(): called on null instance");
       }
       return m_data->impl->getColorCamera();
     }
 
-    void GenericPointCloudGrabber::setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T) {
+    void GenericPointCloudGrabber::setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T){
       if(isNull()){
         throw ICLException("GenericPointCloudGrabber::setCameraWorldFrame(): called on null instance");
       }

--- a/ICLGeom/src/ICLGeom/GenericPointCloudGrabber.h
+++ b/ICLGeom/src/ICLGeom/GenericPointCloudGrabber.h
@@ -71,16 +71,16 @@ namespace icl{
       /// re-initializes the current device
       /** The backend can choose to throw an exception. The syntax
           for reinitialization is defined by each backend individually */
-      void reinit(const std::string &description) ;
+      void reinit(const std::string &description);
 
       /// forwards call to current backend
-      Camera getDepthCamera() const ;
+      Camera getDepthCamera() const;
 
       /// forwards call to current backend
-      Camera getColorCamera() const ;
+      Camera getColorCamera() const;
 
       /// forwards call to current backend
-      void setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T) ;
+      void setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T);
 
 
       /// deferred initialization from ProgArg (most common perhaps)

--- a/ICLGeom/src/ICLGeom/GridSceneObject.cpp
+++ b/ICLGeom/src/ICLGeom/GridSceneObject.cpp
@@ -37,7 +37,7 @@ using namespace icl::qt;
 
 namespace icl{
   namespace geom{
-    void GridSceneObject::init(int nXCells, int nYCells, const std::vector<Vec> &allGridPoints, bool lines, bool quads) {
+    void GridSceneObject::init(int nXCells, int nYCells, const std::vector<Vec> &allGridPoints, bool lines, bool quads){
       this->nXCells = nXCells;
       this->nYCells = nYCells;
 
@@ -71,7 +71,7 @@ namespace icl{
     }
 
     GridSceneObject::GridSceneObject(int nXCells, int nYCells, const std::vector<Vec> &allGridPoints,
-                                     bool lines, bool quads) {
+                                     bool lines, bool quads){
       init(nXCells,nYCells,allGridPoints,lines,quads);
     }
 

--- a/ICLGeom/src/ICLGeom/GridSceneObject.h
+++ b/ICLGeom/src/ICLGeom/GridSceneObject.h
@@ -54,14 +54,14 @@ namespace icl{
       int nYCells; //!< grid height
 
       /// internal initialization method
-      void init(int nXCells, int nYCells, const std::vector<Vec> &allGridPoints, bool lines, bool quads) ;
+      void init(int nXCells, int nYCells, const std::vector<Vec> &allGridPoints, bool lines, bool quads);
 
       public:
       /// creates a GridSceneObject with a given set of vertices
       /** Note: allGridPoints must have nXCells + nYCells elements and its elements must
           be ordered in row-major order */
       GridSceneObject(int nXCells, int nYCells, const std::vector<Vec> &allGridPoints,
-                      bool lines=true, bool quads=true) ;
+                      bool lines=true, bool quads=true);
 
       /// creates a GridSceneObject where the grid is a regular grid in 3D space
       /** the grid nodes are created automatically: node(x,y) = origin + x*dx + y*dy */

--- a/ICLGeom/src/ICLGeom/PCDFileGrabber.cpp
+++ b/ICLGeom/src/ICLGeom/PCDFileGrabber.cpp
@@ -208,7 +208,7 @@ namespace icl{
           }
         }
 
-        const FieldDef &findDef(const std::string &name) {
+        const FieldDef &findDef(const std::string &name){
           std::map<std::string,FieldDef>::const_iterator it = m_typeLUT.find(name);
           if(it == m_typeLUT.end()){
             throw ICLException("PCDFileGrabber: feature type " + name + " not found");

--- a/ICLGeom/src/ICLGeom/PCLPointCloudObject.cpp
+++ b/ICLGeom/src/ICLGeom/PCLPointCloudObject.cpp
@@ -124,14 +124,14 @@ namespace icl{
     }
 
     template<class PCLPointType>
-    pcl::PointCloud<PCLPointType> & PCLPointCloudObject<PCLPointType>::pcl() {
+    pcl::PointCloud<PCLPointType> & PCLPointCloudObject<PCLPointType>::pcl(){
       if(isNull()) throw ICLException("PCLPointCloudObject::pcl(): instance is null");
       return *m_pcl;
     }
 
 
     template<class PCLPointType>
-    const pcl::PointCloud<PCLPointType> & PCLPointCloudObject<PCLPointType>::pcl() const {
+    const pcl::PointCloud<PCLPointType> & PCLPointCloudObject<PCLPointType>::pcl() const{
       return const_cast<PCLPointCloudObject<PCLPointType>*>(this)->pcl();
     }
 
@@ -168,7 +168,7 @@ namespace icl{
     }
 
     template<class PCLPointType>
-    Size  PCLPointCloudObject<PCLPointType>::getSize() const {
+    Size  PCLPointCloudObject<PCLPointType>::getSize() const{
       if(isNull()) throw utils::ICLException("PCLPointCloudObject:getSize(): instance is null");
       if(!isOrganized()) throw utils::ICLException("PCLPointCloud::getSize(): instance is not 2D-ordered");
       return Size(m_pcl->width, m_pcl->height);

--- a/ICLGeom/src/ICLGeom/PCLPointCloudObject.h
+++ b/ICLGeom/src/ICLGeom/PCLPointCloudObject.h
@@ -119,10 +119,10 @@ namespace icl{
       ~PCLPointCloudObject();
 
       /// grants access to the underlying pcl-point-cloud
-      pcl::PointCloud<PCLPointType> &pcl() ;
+      pcl::PointCloud<PCLPointType> &pcl();
 
       /// grants access to the underlying pcl-point-cloud (const)
-      const pcl::PointCloud<PCLPointType> &pcl() const ;
+      const pcl::PointCloud<PCLPointType> &pcl() const;
 
       /// sets wrapped PCL point cloud (const, always deeply copied)
       void setPCL(const pcl::PointCloud<PCLPointType> &pcl);
@@ -137,7 +137,7 @@ namespace icl{
       virtual bool isOrganized() const;
 
       /// returns the 2D size of the pointcloud (throws exception if not ordered)
-      virtual utils::Size getSize() const ;
+      virtual utils::Size getSize() const;
 
       /// return the linearily ordered number of point in the point cloud
       virtual int getDim() const;

--- a/ICLGeom/src/ICLGeom/PointCloudCreator.cpp
+++ b/ICLGeom/src/ICLGeom/PointCloudCreator.cpp
@@ -490,7 +490,7 @@ namespace icl{
       return *m_data->depthCamera;
     }
 
-    const Camera &PointCloudCreator::getColorCamera() const {
+    const Camera &PointCloudCreator::getColorCamera() const{
       if(!hasColorCamera()) throw ICLException("PointCloudCreator::getColorCamera(): no color camera available");
       return *m_data->colorCamera;
     }
@@ -608,7 +608,7 @@ namespace icl{
 #endif
     }
 
-    RGBDMapping PointCloudCreator::getMapping() const {
+    RGBDMapping PointCloudCreator::getMapping() const{
       if(!m_data->colorCamera) throw ICLException("PointCloudCreator::getMapping(): no color camera data available");
       return RGBDMapping(*m_data->colorCamera, m_data->viewRayDirections, m_data->viewRayOffset);
     }

--- a/ICLGeom/src/ICLGeom/PointCloudCreator.h
+++ b/ICLGeom/src/ICLGeom/PointCloudCreator.h
@@ -106,7 +106,7 @@ namespace icl{
       const Camera &getDepthCamera() const;
 
       /// returns the current camera camera (if this was not given, an exception is thrown)
-      const Camera &getColorCamera() const ;
+      const Camera &getColorCamera() const;
 
       /// sets new cameras (reinitializes data structures internally)
       /** This functions is relatively complex, so it should be performed only
@@ -137,7 +137,7 @@ namespace icl{
       /** Only if both- depth and camera camera parameters are available.
           Please note, that the returned shallowly copies the internal
           depth camera viewray array */
-      RGBDMapping getMapping() const ;
+      RGBDMapping getMapping() const;
 
       /// sets up internal heuristical fixes applied to the used depth camera parameters
       /** @param focalLengthMultiplier is used as multiplicative adaption to the orginal depth camera's

--- a/ICLGeom/src/ICLGeom/PointCloudCreatorCL.cpp
+++ b/ICLGeom/src/ICLGeom/PointCloudCreatorCL.cpp
@@ -149,7 +149,7 @@ namespace icl {
       delete[] rgbaData;
 #endif
     }
-    void PointCloudCreatorCL::setDirectionVectors(const utils::Array2D<Vec> &dirs) {
+    void PointCloudCreatorCL::setDirectionVectors(const utils::Array2D<Vec> &dirs){
       if(dirs.getSize() != this->size) throw ICLException("PointCloudCreatorCL::setDirectionVectors: size must not change");
       dirsBuffer.write(dirs.begin(), this->size.getDim()*sizeof(float)*4);
     }

--- a/ICLGeom/src/ICLGeom/PointCloudCreatorCL.h
+++ b/ICLGeom/src/ICLGeom/PointCloudCreatorCL.h
@@ -59,7 +59,7 @@ namespace icl{
 
       /// updates the internally used direction vectors
       /** the underlying chip size must not change, otherwise, and exception is thrown */
-      ICLGeom_API void setDirectionVectors(const utils::Array2D<Vec> &dirs) ;
+      ICLGeom_API void setDirectionVectors(const utils::Array2D<Vec> &dirs);
 
       ///Creates a uncolored pointcloud (called from PointCloudCreator)
       ICLGeom_API void create(bool NEEDS_RAW_TO_MM_MAPPING,const core::Img32f *depthValues,

--- a/ICLGeom/src/ICLGeom/PointCloudGrabber.h
+++ b/ICLGeom/src/ICLGeom/PointCloudGrabber.h
@@ -56,22 +56,22 @@ namespace icl{
       virtual const core::Img8u *getColorImage() const { return 0; }
 
       /// returns current depth camera (CAN be implemented by implementation
-      virtual Camera getDepthCamera() const {
+      virtual Camera getDepthCamera() const{
         throw utils::ICLException("PointCloudGrabber::getDepthCamera() is not implemented by current backend");
       }
 
-      virtual Camera getColorCamera() const {
+      virtual Camera getColorCamera() const{
         throw utils::ICLException("PointCloudGrabber::getColorCamera() is not implemented by current backend");
       }
 
-      virtual void setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T) {
+      virtual void setCameraWorldFrame(const math::FixedMatrix<float,4,4> &T){
         throw utils::ICLException("PointCloudGrabber::setCameraWorldFrame() is not implemented by current backend");
       }
 
 
       /// re-initializes the current device
       /** The backend can choose to throw an exception */
-      virtual void reinit(const std::string &description) {
+      virtual void reinit(const std::string &description){
         throw utils::ICLException("reinit is not implemented for this PointCloudGrabber backend type");
       }
     };

--- a/ICLGeom/src/ICLGeom/PointCloudObject.cpp
+++ b/ICLGeom/src/ICLGeom/PointCloudObject.cpp
@@ -116,7 +116,7 @@ namespace icl{
       return t == Normal || t == RGBA32f || t == Label || t == Depth;
     }
 
-    void PointCloudObject::addFeature(FeatureType t) {
+    void PointCloudObject::addFeature(FeatureType t){
       if(!canAddFeature(t)){
         PointCloudObjectBase::addFeature(t);
         return;
@@ -144,7 +144,7 @@ namespace icl{
       return m_organized;
     }
 
-    Size PointCloudObject::getSize() const {
+    Size PointCloudObject::getSize() const{
       if(!isOrganized()) throw ICLException("SimplePointCloudObject:getSize(): instance is not 2D-ordered");
       return m_dim2D;
     }

--- a/ICLGeom/src/ICLGeom/PointCloudObject.h
+++ b/ICLGeom/src/ICLGeom/PointCloudObject.h
@@ -84,7 +84,7 @@ namespace icl{
       virtual bool isOrganized() const;
 
       /// returns the 2D size of the pointcloud (throws exception if not ordered)
-      virtual utils::Size getSize() const ;
+      virtual utils::Size getSize() const;
 
       /// return the linearily ordered number of point in the point cloud
       virtual int getDim() const;
@@ -124,7 +124,7 @@ namespace icl{
       /// adds normals or colors in hindsight
       /** If the given feature is already contained, calling this function has no effect.
           The function calls lock() and unlock() internally */
-      virtual void addFeature(FeatureType t) ;
+      virtual void addFeature(FeatureType t);
 
       /// deep copy function
       virtual PointCloudObject *copy() const {

--- a/ICLGeom/src/ICLGeom/PointCloudObjectBase.cpp
+++ b/ICLGeom/src/ICLGeom/PointCloudObjectBase.cpp
@@ -362,7 +362,7 @@ namespace icl{
       return m_metaData;
     }
 
-    const std::string & PointCloudObjectBase::getMetaData(const std::string &key) const {
+    const std::string & PointCloudObjectBase::getMetaData(const std::string &key) const{
       std::map<std::string,std::string>::const_iterator it = m_metaData.find(key);
       if(it == m_metaData.end()) throw ICLException("PointCloudObjectBase::getMetaData(key): no meta data with given key ("
                                                      + key + ") was associated with this point cloud");
@@ -497,7 +497,7 @@ namespace icl{
 
     } // end of anonymous namespace
 
-    void PointCloudObjectBase::setColorsFromImage(const ImgBase &image) {
+    void PointCloudObjectBase::setColorsFromImage(const ImgBase &image){
       ICLASSERT_THROW(image.getSize() == getSize(),
                       ICLException("PointCloudObjectBase::setColorsFromImage: "
                                    "image size and point cloud size differ!"));
@@ -568,7 +568,7 @@ namespace icl{
       }
     }
 
-    void PointCloudObjectBase::extractColorsToImage(core::ImgBase &image, bool withAlpha) const {
+    void PointCloudObjectBase::extractColorsToImage(core::ImgBase &image, bool withAlpha) const{
       image.setSize(getSize());
       if(withAlpha){
         if(!supports(PointCloudObjectBase::BGRA) && !supports(PointCloudObjectBase::RGBA32f)){

--- a/ICLGeom/src/ICLGeom/PointCloudObjectBase.h
+++ b/ICLGeom/src/ICLGeom/PointCloudObjectBase.h
@@ -114,13 +114,13 @@ namespace icl{
 
       /// internally used utility method that throws verbose exceptions
       template<class T, int N>
-      core::DataSegment<T,N> &error(const std::string &fname) {
+      core::DataSegment<T,N> &error(const std::string &fname){
         throw utils::ICLException("static feature "+fname+" is not supported by this PointCloudObjectBase instance");
         static core::DataSegment<T,N> dummy; return dummy;
       }
 
       /// internally used utility method that throws verbose exceptions
-      core::DataSegmentBase &error_dyn(const std::string &featureName) {
+      core::DataSegmentBase &error_dyn(const std::string &featureName){
         throw utils::ICLException("dynamic feature "+featureName+" is not supported by this PointCloudObjectBase instance");
         static core::DataSegmentBase dummy; return dummy;
       }
@@ -199,7 +199,7 @@ namespace icl{
           avoid this, call canAddFeature before using this function.
           Implementations of this function are supposed ignore this call
           in cases where the feature is actually already supported */
-      virtual void addFeature(FeatureType t) {
+      virtual void addFeature(FeatureType t){
         throw utils::ICLException("unable to add given feature to point cloud");
       }
 
@@ -207,7 +207,7 @@ namespace icl{
       virtual bool isOrganized() const = 0;
 
       /// returns the 2D size of the pointcloud (throws exception if not ordered)
-      virtual utils::Size getSize() const  = 0;
+      virtual utils::Size getSize() const = 0;
 
       /// return the linearily ordered number of point in the point cloud
       virtual int getDim() const = 0;
@@ -301,11 +301,11 @@ namespace icl{
 
       /// tints the point cloud pixel from the given image data
       /** The image size must be equal to the point cloud size*/
-      void setColorsFromImage(const core::ImgBase &image) ;
+      void setColorsFromImage(const core::ImgBase &image);
 
       /// extracts the color information and stores it into the given image
       /** The image size and color format is adapted if necessary */
-      void extractColorsToImage(core::ImgBase &image, bool withAlpha=false) const ;
+      void extractColorsToImage(core::ImgBase &image, bool withAlpha=false) const;
 
       /// sets the color that is used to render points if color information is available
       void setDefaultVertexColor(const GeomColor &color);
@@ -360,7 +360,7 @@ namespace icl{
       const std::map<std::string,std::string> &getMetaData() const;
 
       /// returns the meta data associated with a given key
-      const std::string &getMetaData(const std::string &key) const ;
+      const std::string &getMetaData(const std::string &key) const;
 
       /// returns whether meta data to the given key is associated
       bool hasMetaData(const std::string &key) const;

--- a/ICLGeom/src/ICLGeom/PointCloudSegment.cpp
+++ b/ICLGeom/src/ICLGeom/PointCloudSegment.cpp
@@ -72,7 +72,7 @@ namespace icl{
     }
 
 
-    Mat PointCloudSegment::computeEigenVectorFrame() const {
+    Mat PointCloudSegment::computeEigenVectorFrame() const{
       const math::Vec3 &x = eigenvectors[0];
       const math::Vec3 &y = eigenvectors[1];
 
@@ -86,7 +86,7 @@ namespace icl{
 
 
     /// returns week pointer to the i-th child (already casted to PointCloudSegment type)
-    utils::SmartPtr<PointCloudSegment>  PointCloudSegment::getSubSegment(int i) {
+    utils::SmartPtr<PointCloudSegment>  PointCloudSegment::getSubSegment(int i){
       if(i<0 || i >= getChildCount()){
         throw utils::ICLException("PointCloudSegment:getSubSegment: invalid index!");
       }

--- a/ICLGeom/src/ICLGeom/PointCloudSegment.h
+++ b/ICLGeom/src/ICLGeom/PointCloudSegment.h
@@ -67,7 +67,7 @@ namespace icl{
 
       PointCloudSegment *copy() const;
 
-      Mat computeEigenVectorFrame() const ;
+      Mat computeEigenVectorFrame() const;
 
       /// updates the instances features
       /** parent instances update their features from their children's featuers */
@@ -83,8 +83,7 @@ namespace icl{
       }
 
       /// returns week pointer to the i-th child (already casted to PointCloudSegment type)
-      utils::SmartPtr<PointCloudSegment> getSubSegment(int i)
-        ;
+      utils::SmartPtr<PointCloudSegment> getSubSegment(int i);
 
       /// creates a flattened deep copy of the segment
       utils::SmartPtr<PointCloudSegment> flatten() const;

--- a/ICLGeom/src/ICLGeom/PoseEstimator.cpp
+++ b/ICLGeom/src/ICLGeom/PoseEstimator.cpp
@@ -140,8 +140,7 @@ namespace icl{
 
 
     template<class T>
-    FixedMatrix<T,4,4> PoseEstimator::map(const DynMatrix<T> &Xs, const DynMatrix<T> &Ys, PoseEstimator::MapMode mode)
-      {
+    FixedMatrix<T,4,4> PoseEstimator::map(const DynMatrix<T> &Xs, const DynMatrix<T> &Ys, PoseEstimator::MapMode mode){
       ICLASSERT_THROW(Xs.rows() == 3 || Xs.rows() == 4, IncompatibleMatrixDimensionException("PoseEstimator::map: Xs.rows must be 3 or 4 (for homogeneous coordinates)"));
       ICLASSERT_THROW(Ys.rows() == 3 || Ys.rows() == 4, IncompatibleMatrixDimensionException("PoseEstimator::map: Ys.rows must be 3 or 4 (for homogeneous coordinates)"));
       ICLASSERT_THROW(Xs.cols() == Ys.cols(), IncompatibleMatrixDimensionException("PoseEstimator::map: Point count in Xs and Ys must be equal"));
@@ -318,7 +317,7 @@ namespace icl{
 
     }
 
-    template ICLGeom_API FixedMatrix<icl32f, 4, 4> PoseEstimator::map(const DynMatrix<icl32f>&, const DynMatrix<icl32f>&, PoseEstimator::MapMode mode) ;
-    template ICLGeom_API FixedMatrix<icl64f, 4, 4> PoseEstimator::map(const DynMatrix<icl64f>&, const DynMatrix<icl64f>&, PoseEstimator::MapMode mode) ;
+    template ICLGeom_API FixedMatrix<icl32f, 4, 4> PoseEstimator::map(const DynMatrix<icl32f>&, const DynMatrix<icl32f>&, PoseEstimator::MapMode mode);
+    template ICLGeom_API FixedMatrix<icl64f, 4, 4> PoseEstimator::map(const DynMatrix<icl64f>&, const DynMatrix<icl64f>&, PoseEstimator::MapMode mode);
   } // namespace geom
 }

--- a/ICLGeom/src/ICLGeom/PoseEstimator.h
+++ b/ICLGeom/src/ICLGeom/PoseEstimator.h
@@ -73,15 +73,13 @@ namespace icl{
           - row-cout 3 or 4 (if it is 4, the last row is not used at all)
           - at least one column (however you'll need 3 columns for 6D mapping */
       template<class T> ICLGeom_API
-      static math::FixedMatrix<T,4,4> map(const math::DynMatrix<T> &Xs, const math::DynMatrix<T> &Ys, MapMode mode=RigidBody)
-      ;
+      static math::FixedMatrix<T,4,4> map(const math::DynMatrix<T> &Xs, const math::DynMatrix<T> &Ys, MapMode mode=RigidBody);
 
       /// Convenienc template that uses FixedMatrix inputs (available for T=icl32f and T=icl64f)
       /** The inputs's data points are passes to the main map-function using a shallow DynMatrix<T> wrappter*/
       template<class T, unsigned int NUM_POINTS>
       static math::FixedMatrix<T,4,4> map(const math::FixedMatrix<T,NUM_POINTS,3> &Xs,
-                                          const math::FixedMatrix<T,NUM_POINTS,3> &Ys, MapMode mode=RigidBody)
-        {
+                                          const math::FixedMatrix<T,NUM_POINTS,3> &Ys, MapMode mode=RigidBody){
         return map(Xs.dyn(),Ys.dyn(), mode);
       }
 
@@ -89,14 +87,12 @@ namespace icl{
       /** The inputs's data points are passes to the main map-function using a shallow DynMatrix<T> wrappter*/
       template<class T, unsigned int NUM_POINTS>
       static math::FixedMatrix<T,4,4> map(const math::FixedMatrix<T,NUM_POINTS,4> &Xs,
-                                    const math::FixedMatrix<T,NUM_POINTS,4> &Ys, MapMode mode=RigidBody)
-        {
+                                    const math::FixedMatrix<T,NUM_POINTS,4> &Ys, MapMode mode=RigidBody){
         return map(Xs.dyn(),Ys.dyn(), mode);
       }
 
       /// Convenience function that passes std::vector<Vec> data as DynMatrix<T> to other map function
-      static Mat map(const std::vector<Vec> &Xs, const std::vector<Vec> &Ys, MapMode mode=RigidBody)
-      {
+      static Mat map(const std::vector<Vec> &Xs, const std::vector<Vec> &Ys, MapMode mode=RigidBody){
         ICLASSERT_THROW(Xs.size() == Ys.size(), utils::ICLException("PoseEstimator::map: need same number of input- and output-points"));
         math::DynMatrix<double> XsD(Xs.size(),3),YsD(Ys.size(),3);
         for(unsigned int i=0;i<Xs.size();++i){

--- a/ICLGeom/src/ICLGeom/Posit.cpp
+++ b/ICLGeom/src/ICLGeom/Posit.cpp
@@ -169,7 +169,7 @@ namespace icl{
       return sqrt(m[0]*m[0] + m[1]*m[1] + m[2]*m[2]);
     }
 
-    const Posit::Result &Posit::findPose(const std::vector<Point32f> &imagePoints, const Camera &cam) {
+    const Posit::Result &Posit::findPose(const std::vector<Point32f> &imagePoints, const Camera &cam){
       Point32f pp = cam.getPrincipalPointOffset();
       float fx = cam.getFocalLength()*cam.getSamplingResolutionX();
       float fy = cam.getFocalLength()*cam.getSamplingResolutionY();
@@ -177,7 +177,7 @@ namespace icl{
     }
 
     const Posit::Result &Posit::findPose(const std::vector<Point32f> &imagePoints, const Point &pp,
-                                         float fx, float fy) {
+                                         float fx, float fy){
       BENCHMARK_THIS_FUNCTION;
 
       const int N = data->N;

--- a/ICLGeom/src/ICLGeom/Posit.h
+++ b/ICLGeom/src/ICLGeom/Posit.h
@@ -120,7 +120,7 @@ namespace icl{
       };
 
       /// main function to obtain an objects pose from given image points and camera
-      const Result &findPose(const std::vector<utils::Point32f> &imagePoints, const Camera &cam) ;
+      const Result &findPose(const std::vector<utils::Point32f> &imagePoints, const Camera &cam);
 
       /// utility wrapper if no whole camera is available
       /** Please note, that the focal lenghts have to be combined with a cameras
@@ -143,7 +143,7 @@ namespace icl{
       */
       const Result &findPose(const std::vector<utils::Point32f> &imagePoints,
                              const utils::Point &principlePointOffset,
-                             float focalLengthX, float focalLengthY) ;
+                             float focalLengthX, float focalLengthY);
     };
 
   } // namespace geom

--- a/ICLGeom/src/ICLGeom/ProtoBufSerializationDevice.cpp
+++ b/ICLGeom/src/ICLGeom/ProtoBufSerializationDevice.cpp
@@ -46,7 +46,7 @@ namespace icl{
       return !protoBufObject;
     }
 
-    void ProtoBufSerializationDevice::null_check(const std::string &function) {
+    void ProtoBufSerializationDevice::null_check(const std::string &function){
       if(isNull()) throw ICLException(function + ": instance is null");
     }
 

--- a/ICLGeom/src/ICLGeom/ProtoBufSerializationDevice.h
+++ b/ICLGeom/src/ICLGeom/ProtoBufSerializationDevice.h
@@ -48,7 +48,7 @@ namespace icl{
                                                     public PointCloudSerializer::DeserializationDevice{
       protected:
 
-      void null_check(const std::string &function) ;
+      void null_check(const std::string &function);
 
       RSBPointCloud *protoBufObject;
 

--- a/ICLGeom/src/ICLGeom/RSBPointCloudGrabber.cpp
+++ b/ICLGeom/src/ICLGeom/RSBPointCloudGrabber.cpp
@@ -138,7 +138,7 @@ namespace icl{
       PointCloudSerializer::deserialize(dst, m_data->sdev);
     }
 
-    Camera RSBPointCloudGrabber::getDepthCamera() const {
+    Camera RSBPointCloudGrabber::getDepthCamera() const{
       if(!m_data->depthCam){
         throw ICLException("RSBPointCloudGrabber::getDepthCamera(): the depth camera can only "
                            "be returned if explicitly given to the grabber creation string "
@@ -148,7 +148,7 @@ namespace icl{
       return *m_data->depthCam;
     }
 
-    Camera RSBPointCloudGrabber::getColorCamera() const {
+    Camera RSBPointCloudGrabber::getColorCamera() const{
       if(!m_data->colorCam){
         throw ICLException("RSBPointCloudGrabber::getColorCamera(): the color camera can only "
                            "be returned if explicitly given to the grabber creation string "

--- a/ICLGeom/src/ICLGeom/RSBPointCloudGrabber.h
+++ b/ICLGeom/src/ICLGeom/RSBPointCloudGrabber.h
@@ -67,10 +67,10 @@ namespace icl{
       virtual void grab(PointCloudObjectBase &dst);
 
       /// returns depth camera (only if explicitly given in the creation string)
-      Camera getDepthCamera() const ;
+      Camera getDepthCamera() const;
 
       /// returns color camera (only if explicitly given in the creation string)
-      Camera getColorCamera() const ;
+      Camera getColorCamera() const;
     };
   } // namespace geom
 }

--- a/ICLGeom/src/ICLGeom/RansacBasedPoseEstimator.cpp
+++ b/ICLGeom/src/ICLGeom/RansacBasedPoseEstimator.cpp
@@ -168,7 +168,7 @@ namespace icl{
       setPropertyValue("store last consensus set",on);
     }
 
-    std::vector<utils::Point32f>  RansacBasedPoseEstimator::getLastConsensusSet() {
+    std::vector<utils::Point32f>  RansacBasedPoseEstimator::getLastConsensusSet(){
       bool hasSet = getPropertyValue("store last consensus set");
       if(!hasSet) throw utils::ICLException("RansacBasedPoseEstimator::getLastConsensusSet() even though "
                                             "'store last consensus set' property was not set to 'true'");

--- a/ICLGeom/src/ICLGeom/RansacBasedPoseEstimator.h
+++ b/ICLGeom/src/ICLGeom/RansacBasedPoseEstimator.h
@@ -72,7 +72,7 @@ namespace icl{
 
       void setStoreLastConsensusSet(bool);
 
-      std::vector<utils::Point32f> getLastConsensusSet() ;
+      std::vector<utils::Point32f> getLastConsensusSet();
 
       /// fit from planar target
       Result fit(const std::vector<utils::Point32f> &modelPoints,

--- a/ICLGeom/src/ICLGeom/RayCastOctreeObject.cpp
+++ b/ICLGeom/src/ICLGeom/RayCastOctreeObject.cpp
@@ -134,7 +134,7 @@ namespace icl{
     }
 
     /// casts a ray and returns the point closest to the ray-offset
-    Vec RayCastOctreeObject::rayCastClosest(const ViewRay &ray, float maxDist) const {
+    Vec RayCastOctreeObject::rayCastClosest(const ViewRay &ray, float maxDist) const{
       std::vector<Vec> rays = rayCast(ray,maxDist);
       if(!rays.size()) throw ICLException("RayCastOctreeObject::rayCastClosest:"
                                             " no point found in radius" );

--- a/ICLGeom/src/ICLGeom/RayCastOctreeObject.h
+++ b/ICLGeom/src/ICLGeom/RayCastOctreeObject.h
@@ -103,7 +103,7 @@ namespace icl{
       ICLGeom_API std::vector<Vec> rayCastSort(const ViewRay &ray, float maxDist = 1) const;
 
       /// casts a ray and returns the point closest to the ray-offset
-      ICLGeom_API Vec rayCastClosest(const ViewRay &ray, float maxDist = 1) const ;
+      ICLGeom_API Vec rayCastClosest(const ViewRay &ray, float maxDist = 1) const;
     };
 
   }

--- a/ICLGeom/src/ICLGeom/Scene.cpp
+++ b/ICLGeom/src/ICLGeom/Scene.cpp
@@ -1286,7 +1286,7 @@ namespace icl{
       return r ? r : 1;
     }
 
-    SceneLight &Scene::getLight(int index) {
+    SceneLight &Scene::getLight(int index){
       if(index < 0 || index > 7) throw ICLException("invalid light index");
       if(!m_lights[index]){
         m_lights[index] = SmartPtr<SceneLight>(new SceneLight(this,index));
@@ -1295,7 +1295,7 @@ namespace icl{
       return *m_lights[index];
     }
 
-    const SceneLight &Scene::getLight(int index) const {
+    const SceneLight &Scene::getLight(int index) const{
       return const_cast<Scene*>(this)->getLight(index);
     }
 
@@ -1330,12 +1330,12 @@ namespace icl{
     }
 
 
-    SceneObject *Scene::getObject(int index) {
+    SceneObject *Scene::getObject(int index){
       if(index < 0 || index >= (int)m_objects.size()) throw ICLException("Scene::getObject: invalid index");
       return m_objects[index].get();
     }
 
-    const SceneObject *Scene::getObject(int index) const {
+    const SceneObject *Scene::getObject(int index) const{
       return const_cast<Scene*>(this)->getObject(index);
     }
 
@@ -1344,7 +1344,7 @@ namespace icl{
       else return find_object_recursive(o->getChild(indices[idx]),idx+1,indices);
     }
 
-    SceneObject *Scene::getObject(const std::vector<int> recursiveIndices) {
+    SceneObject *Scene::getObject(const std::vector<int> recursiveIndices){
       if(!recursiveIndices.size()) throw ICLException("Scene::getObject: recursiveIndices's size was 0");
       if(recursiveIndices.size() == 1) return getObject(recursiveIndices.front());
       SceneObject *found = 0;
@@ -1356,7 +1356,7 @@ namespace icl{
       return found;
     }
 
-    SceneObject *Scene::getObject(const std::vector<int> recursiveIndices) const {
+    SceneObject *Scene::getObject(const std::vector<int> recursiveIndices) const{
       return const_cast<Scene*>(this)->getObject(recursiveIndices);
     }
 
@@ -1370,7 +1370,7 @@ namespace icl{
       return false;
     }
 
-    std::vector<int> Scene::findPath(const SceneObject *o) const {
+    std::vector<int> Scene::findPath(const SceneObject *o) const{
       std::vector<int> path;
       for(unsigned int i=0;i<m_objects.size();++i){
         path.push_back(i);

--- a/ICLGeom/src/ICLGeom/Scene.h
+++ b/ICLGeom/src/ICLGeom/Scene.h
@@ -222,11 +222,11 @@ namespace icl{
 
       /// returns contained object at given index
       /** If the index is not valid, an exception is thrown */
-      SceneObject *getObject(int index) ;
+      SceneObject *getObject(int index);
 
       /// returns contained object at given index (const)
       /** If the index is not valid, an exception is thrown */
-      const SceneObject *getObject(int index) const ;
+      const SceneObject *getObject(int index) const;
 
       /// returns a child that is deeper in the scene graph
       /** e.g. if recursiveIndices is [1,2,3], then first, the Scene's object at
@@ -234,7 +234,7 @@ namespace icl{
           objects child at index 3 is returned.
           An exception is thrown if one of the indices is wrong.
           */
-      SceneObject *getObject(const std::vector<int> recursiveIndices) ;
+      SceneObject *getObject(const std::vector<int> recursiveIndices);
 
       /// returns a child that is deeper in the scene graph (const)
       /** e.g. if recursiveIndices is [1,2,3], then first, the Scene's object at
@@ -242,12 +242,12 @@ namespace icl{
           objects child at index 3 is returned.
           An exception is thrown if one of the indices is wrong.
           */
-      SceneObject *getObject(const std::vector<int> recursiveIndices) const ;
+      SceneObject *getObject(const std::vector<int> recursiveIndices) const;
 
       /// finds the recursive indices for a given object.
       /** If no exceptions are thrown, getObject(findPath(o)) is always o.
           throws ans exception if the given object cannot be found. */
-      std::vector<int> findPath(const SceneObject *o) const ;
+      std::vector<int> findPath(const SceneObject *o) const;
 
       /// deletes and removes all objects, handlers and callbacks
       /** If camerasToo is set to true, also all cameras are removed */
@@ -354,12 +354,12 @@ namespace icl{
       /** The returned reference cam be used to set lighting parameters.
           Since OpenGL does only support 8 lights, allowed indices are 0-7.
           If another index is passed, an exception is thrown. */
-      SceneLight &getLight(int index) ;
+      SceneLight &getLight(int index);
 
       /// returns a const reference to a light with given index
       /** Since OpenGL does only support 8 lights, allowed indices are 0-7.
           If another index is passed, an exception is thrown. */
-      const SceneLight &getLight(int index) const ;
+      const SceneLight &getLight(int index) const;
 
 
       /// sets whether OpenGL's lighting is globally activated

--- a/ICLGeom/src/ICLGeom/SceneObject.cpp
+++ b/ICLGeom/src/ICLGeom/SceneObject.cpp
@@ -632,7 +632,7 @@ namespace icl{
       ICL_DELETE(m_fragmentShader);
     }
 
-    SceneObject::SceneObject(const std::string &objFileName) :
+    SceneObject::SceneObject(const std::string &objFileName):
       m_lineColorsFromVertices(false),
       m_triangleColorsFromVertices(false),
       m_quadColorsFromVertices(false),
@@ -1064,7 +1064,7 @@ namespace icl{
       return ts;
     }
 
-    Vec SceneObject::getClosestVertex(const Vec &pWorld, bool relative) {
+    Vec SceneObject::getClosestVertex(const Vec &pWorld, bool relative){
       std::vector<Vec> ts = getTransformedVertices();
       if(!ts.size()) throw ICLException("getClosestVertex called on an object that has not vertices");
       std::vector<float> distances(ts.size());

--- a/ICLGeom/src/ICLGeom/SceneObject.h
+++ b/ICLGeom/src/ICLGeom/SceneObject.h
@@ -196,7 +196,7 @@ namespace icl{
 
 
       /// creates a scene object from given .obj file
-      ICLGeom_API SceneObject(const std::string &objFileName) ;
+      ICLGeom_API SceneObject(const std::string &objFileName);
 
       /// deep copy of SceneObject instance
       /** The new instance's parent is set to null, i.e. it must
@@ -660,7 +660,7 @@ namespace icl{
       /// returns the vertex, that is closest to the given point in wold coordinates
       /** If relative is true, the vertex is returned in object-coordinates, otherwise
           it is returned in world coordinates */
-      ICLGeom_API Vec getClosestVertex(const Vec &pWorld, bool relative = false) ;
+      ICLGeom_API Vec getClosestVertex(const Vec &pWorld, bool relative = false);
 
       /// sets the visibility of this object
       ICLGeom_API void setVisible(bool visible, bool recursive = true);

--- a/ICLGeom/src/ICLGeom/ShaderUtil.cpp
+++ b/ICLGeom/src/ICLGeom/ShaderUtil.cpp
@@ -50,7 +50,7 @@ namespace icl{
       m_shadowBias(shadowBias),
       renderingShadow(false){}
 
-    const Camera &ShaderUtil::getCurrentCamera() const {
+    const Camera &ShaderUtil::getCurrentCamera() const{
       if(!m_camera) throw utils::ICLException("shader util has no camera!");
       return *m_camera;
     }

--- a/ICLGeom/src/ICLGeom/ShaderUtil.h
+++ b/ICLGeom/src/ICLGeom/ShaderUtil.h
@@ -62,7 +62,7 @@ namespace icl{
 
       void activateShader(Primitive::Type type, bool withShadow);
       void deactivateShaders();
-      const Camera &getCurrentCamera() const ;
+      const Camera &getCurrentCamera() const;
       static void recompilePerPixelShader(icl::qt::GLFragmentShader** shaders, const icl::utils::SmartPtr<SceneLight>* lights, int numShadowLights);
     };
   }

--- a/ICLGeom/src/ICLGeom/ViewRay.cpp
+++ b/ICLGeom/src/ICLGeom/ViewRay.cpp
@@ -46,7 +46,7 @@ namespace icl{
       this->offset[3]=this->direction[3]=1;
     }
 
-    Vec ViewRay::getIntersection(const PlaneEquation &plane) const {
+    Vec ViewRay::getIntersection(const PlaneEquation &plane) const{
       return Camera::getIntersection(*this,plane);
     }
 

--- a/ICLGeom/src/ICLGeom/ViewRay.h
+++ b/ICLGeom/src/ICLGeom/ViewRay.h
@@ -58,7 +58,7 @@ namespace icl{
 
       /// calculates line-plane intersection
       /** @see static Camera::getIntersection function */
-      Vec getIntersection(const PlaneEquation &plane) const ;
+      Vec getIntersection(const PlaneEquation &plane) const;
 
       /// ray-triangle intersection results
       enum TriangleIntersection{

--- a/ICLIO/src/ICLIO/ConfigurableRemoteServer.cpp
+++ b/ICLIO/src/ICLIO/ConfigurableRemoteServer.cpp
@@ -60,7 +60,7 @@ namespace icl{
         remoteServer = factory.createRemoteServer(serverScope);
       }
 
-      virtual void setPropertyValue(const std::string &propertyName, const Any &value) {
+      virtual void setPropertyValue(const std::string &propertyName, const Any &value){
         remoteServer->call<void>("setPropertyValue",pack(propertyName+"="+value));
       }
       virtual std::vector<std::string> getPropertyList() const{

--- a/ICLIO/src/ICLIO/FourCC.h
+++ b/ICLIO/src/ICLIO/FourCC.h
@@ -62,7 +62,7 @@ namespace icl{
       }
 
       /// initialization utility method
-      void init(const std::string &key) {
+      void init(const std::string &key){
         if(key.length() != 4) throw utils::ICLException("FourCC::FourCC(string): invalid fourcc code " + key);
         if(key == "null") this->key = 0;
         else this->key = (((icl32u)(key[0])<<0)|((icl32u)(key[1])<<8)|((icl32u)(key[2])<<16)|((icl32u)(key[3])<<24));

--- a/ICLIO/src/ICLIO/GenericGrabber.cpp
+++ b/ICLIO/src/ICLIO/GenericGrabber.cpp
@@ -70,7 +70,7 @@ namespace icl{
           return &inst;
         }
 
-        Grabber* createGrabber(const GrabberDeviceDescription &desc) {
+        Grabber* createGrabber(const GrabberDeviceDescription &desc){
           Mutex::Locker l(mutex);
 
           GPM::iterator it = gpm.find(desc.name());
@@ -130,7 +130,7 @@ namespace icl{
       }
     }
 
-    void GenericGrabber::init(const ProgArg &pa) {
+    void GenericGrabber::init(const ProgArg &pa){
       init(*pa,(*pa) + "=" + *utils::pa(pa.getID(),1));
     }
 

--- a/ICLIO/src/ICLIO/GenericGrabber.h
+++ b/ICLIO/src/ICLIO/GenericGrabber.h
@@ -67,7 +67,7 @@ namespace icl {
 
         /// Initialized the grabber from given prog-arg
         /** The progarg needs two sub-parameters */
-        GenericGrabber(const utils::ProgArg &pa) {
+        GenericGrabber(const utils::ProgArg &pa):m_poGrabber(0),m_remoteServer(0){
           init(pa);
         }
 
@@ -75,7 +75,7 @@ namespace icl {
         /** internally this function calls the init function immediately*/
         GenericGrabber(const std::string &devicePriorityList,
                        const std::string &params,
-                       bool notifyErrors = true) {
+                       bool notifyErrors = true):m_poGrabber(0),m_remoteServer(0){
           init(devicePriorityList,params,notifyErrors);
         }
 
@@ -170,10 +170,10 @@ namespace icl {
       **/
         void init(const std::string &devicePriorityList,
                   const std::string &params,
-                  bool notifyErrors = true) ;
+                  bool notifyErrors = true);
 
         /// this method works just like the other init method
-        void init(const utils::ProgArg &pa) ;
+        void init(const utils::ProgArg &pa);
 
         /// resets resource on given devices (e.g. firewire bus)
         static void resetBus(const std::string &deviceList="dc", bool verbose=false);

--- a/ICLIO/src/ICLIO/Grabber.cpp
+++ b/ICLIO/src/ICLIO/Grabber.cpp
@@ -340,7 +340,6 @@ namespace icl{
     void GrabberRegister::registerGrabberType(const std::string &grabberid,
                                    utils::Function<Grabber *, const std::string &> creator,
                                    utils::Function<const std::vector<GrabberDeviceDescription> &,std::string,bool> device_list)
-    
     {
       Mutex::Locker l(mutex);
       GFM::iterator it = gfm.find(grabberid);
@@ -354,7 +353,6 @@ namespace icl{
 
     void GrabberRegister::registerGrabberBusReset(const std::string &grabberid,
                                    utils::Function<void, bool> reset_function)
-    
     {
       Mutex::Locker l(mutex);
       GBRM::iterator it = gbrm.find(grabberid);
@@ -365,7 +363,6 @@ namespace icl{
     }
 
     void GrabberRegister::addGrabberDescription(const std::string &grabber_description)
-    
     {
       Mutex::Locker l(mutex);
       GDS::iterator it = gds.find(grabber_description);
@@ -375,7 +372,7 @@ namespace icl{
       gds.insert(grabber_description);
     }
 
-    Grabber* GrabberRegister::createGrabber(const std::string &grabberid, const string &param) {
+    Grabber* GrabberRegister::createGrabber(const std::string &grabberid, const string &param){
       Mutex::Locker l(mutex);
       GFM::iterator it = gfm.find(grabberid);
       if(it != gfm.end()){

--- a/ICLIO/src/ICLIO/Grabber.h
+++ b/ICLIO/src/ICLIO/Grabber.h
@@ -353,17 +353,14 @@ namespace icl {
 
         void registerGrabberType(const std::string &grabberid,
                                    utils::Function<Grabber *, const std::string &> creator,
-                                   utils::Function<const std::vector<GrabberDeviceDescription> &,std::string,bool> device_list)
-        ;
+                                   utils::Function<const std::vector<GrabberDeviceDescription> &,std::string,bool> device_list);
 
         void registerGrabberBusReset(const std::string &grabberid,
-                                   utils::Function<void, bool> reset_function)
-        ;
+                                   utils::Function<void, bool> reset_function);
 
-        void addGrabberDescription(const std::string &grabber_description)
-        ;
+        void addGrabberDescription(const std::string &grabber_description);
 
-        Grabber* createGrabber(const std::string &grabberid, const std::string &param) ;
+        Grabber* createGrabber(const std::string &grabberid, const std::string &param);
 
         std::vector<std::string> getRegisteredGrabbers();
 

--- a/ICLIO/src/ICLIO/JPEGDecoder.cpp
+++ b/ICLIO/src/ICLIO/JPEGDecoder.cpp
@@ -96,12 +96,12 @@ namespace icl{
       decode_internal(0,data,maxDataLen,dest);
     }
 
-    void JPEGDecoder::decode(File &file, ImgBase **dest) {
+    void JPEGDecoder::decode(File &file, ImgBase **dest){
       decode_internal(&file,0,0,dest);
       return;
     }
 
-    void JPEGDecoder::decode_internal(File *file, const unsigned char *data, unsigned int maxDataLen, ImgBase **dest) {
+    void JPEGDecoder::decode_internal(File *file, const unsigned char *data, unsigned int maxDataLen, ImgBase **dest){
       ICLASSERT_RETURN(!(file&&data));
       ICLASSERT_RETURN(!(!file&&!data));
       ICLASSERT_RETURN(dest);

--- a/ICLIO/src/ICLIO/JPEGDecoder.h
+++ b/ICLIO/src/ICLIO/JPEGDecoder.h
@@ -44,7 +44,7 @@ namespace icl{
       /** @param file must be opened in mode readBinary or not opend
           @param dst image, which is adapted to the found image parameters
       */
-      static void decode(utils::File &file, core::ImgBase **dst) ;
+      static void decode(utils::File &file, core::ImgBase **dst);
 
       /// Decode a data stream (E.g. used for Decoding Motion-JPEG streams in unicap's DefaultConvertEngine)
       /** @param data jpeg data stream (must be valid, otherwise unpredictable behaviour occurs
@@ -59,7 +59,7 @@ namespace icl{
       private:
       /// internal utility function, which does all the work
       static void decode_internal(utils::File *file,const unsigned char *data,
-                                  unsigned int maxDataLen, core::ImgBase **dst) ;
+                                  unsigned int maxDataLen, core::ImgBase **dst);
     };
   } // namespace io
 }

--- a/ICLIO/src/ICLIO/Kinect2Grabber.cpp
+++ b/ICLIO/src/ICLIO/Kinect2Grabber.cpp
@@ -262,7 +262,7 @@ namespace icl{
 
     };
 
-    Kinect2Grabber::Kinect2Grabber(Kinect2Grabber::Mode mode, int deviceID)  {
+    Kinect2Grabber::Kinect2Grabber(Kinect2Grabber::Mode mode, int deviceID) {
       if(mode != DUMMY_MODE){
         LibFreenect2Context &ctx = LibFreenect2Context::instance();
         m_impl = new Impl;

--- a/ICLIO/src/ICLIO/Kinect2Grabber.h
+++ b/ICLIO/src/ICLIO/Kinect2Grabber.h
@@ -47,7 +47,7 @@ namespace icl{
         /// returns a list of attached kinect devices
         ICLIO_API static const std::vector<GrabberDeviceDescription> &getDeviceList(bool rescan);
 
-        ICLIO_API Kinect2Grabber(Mode mode = GRAB_DEPTH_IMAGE, int deviceID=0) ;
+        ICLIO_API Kinect2Grabber(Mode mode = GRAB_DEPTH_IMAGE, int deviceID=0);
 
         /// Destructor
         ICLIO_API ~Kinect2Grabber();

--- a/ICLIO/src/ICLIO/KinectGrabber.cpp
+++ b/ICLIO/src/ICLIO/KinectGrabber.cpp
@@ -625,17 +625,14 @@ namespace icl{
       }
     };
 
-    KinectGrabber::KinectGrabber(KinectGrabber::Mode mode, int deviceID, const Size &size)
-       {
+    KinectGrabber::KinectGrabber(KinectGrabber::Mode mode, int deviceID, const Size &size) {
       init(mode, str(deviceID),size);
     }
-    KinectGrabber::KinectGrabber(KinectGrabber::Mode mode, const std::string &idOrSerial, const Size &size)
-       {
+    KinectGrabber::KinectGrabber(KinectGrabber::Mode mode, const std::string &idOrSerial, const Size &size) {
       init(mode, idOrSerial,size);
     }
 
-    void KinectGrabber::init(KinectGrabber::Mode mode, const std::string &idOrSerial, const Size &size)
-      {
+    void KinectGrabber::init(KinectGrabber::Mode mode, const std::string &idOrSerial, const Size &size){
 
       FreenectContext::getFreenectContext().start();
       m_impl = new Impl(mode,idOrSerial,size);

--- a/ICLIO/src/ICLIO/KinectGrabber.h
+++ b/ICLIO/src/ICLIO/KinectGrabber.h
@@ -49,14 +49,14 @@ namespace icl{
         ICLIO_API static const std::vector<GrabberDeviceDescription> &getDeviceList(bool rescan);
 
         ICLIO_API KinectGrabber(Mode mode = GRAB_DEPTH_IMAGE, int deviceID=0,
-                                const utils::Size &size=utils::Size::VGA) ;
+                                const utils::Size &size=utils::Size::VGA);
 
         ICLIO_API KinectGrabber(Mode mode, const std::string &deviceIDOrSerial,
-                                const utils::Size &size=utils::Size::VGA) ;
+                                const utils::Size &size=utils::Size::VGA);
 
       private:
         ICLIO_API  void init(Mode mode, const std::string &deviceIDOrSerial,
-                             const utils::Size &size) ;
+                             const utils::Size &size);
       public:
 
         /// Destructor

--- a/ICLIO/src/ICLIO/LibAVVideoWriter.cpp
+++ b/ICLIO/src/ICLIO/LibAVVideoWriter.cpp
@@ -327,7 +327,7 @@ namespace icl{
     }
 
     LibAVVideoWriter::LibAVVideoWriter(const std::string &filename, const std::string &fourcc,
-                                       double fps, Size frame_size) :
+                                       double fps, Size frame_size):
       m_data(new Data(filename, fourcc, fps, frame_size)){
     }
 

--- a/ICLIO/src/ICLIO/LibAVVideoWriter.h
+++ b/ICLIO/src/ICLIO/LibAVVideoWriter.h
@@ -64,7 +64,7 @@ namespace icl{
         @param frame_size size of the frames to be written out
             **/
     LibAVVideoWriter(const std::string &filename, const std::string &fourcc,
-                          double fps, utils::Size frame_size) ;
+                          double fps, utils::Size frame_size);
 
 
   	/// Destructor

--- a/ICLIO/src/ICLIO/OpenCVCamGrabber.cpp
+++ b/ICLIO/src/ICLIO/OpenCVCamGrabber.cpp
@@ -36,7 +36,7 @@ using namespace icl::core;
 namespace icl{
   namespace io{
 
-    OpenCVCamGrabber::OpenCVCamGrabber(int dev)  {
+    OpenCVCamGrabber::OpenCVCamGrabber(int dev) :device(dev),m_buffer(0){
       cvc = cvCaptureFromCAM(dev);
       if(!cvc){
         throw ICLException("unable to create OpenCVCamGrabberImpl with device index "

--- a/ICLIO/src/ICLIO/OpenCVCamGrabber.h
+++ b/ICLIO/src/ICLIO/OpenCVCamGrabber.h
@@ -82,7 +82,7 @@ namespace icl{
           - 700 Direct Show Video Input
           (e.g. device ID 301 selects the 2nd firewire device)
        */
-        OpenCVCamGrabber(int dev=0) ;
+        OpenCVCamGrabber(int dev=0);
 
         /// Destructor
         ~OpenCVCamGrabber();

--- a/ICLIO/src/ICLIO/OpenCVVideoGrabber.cpp
+++ b/ICLIO/src/ICLIO/OpenCVVideoGrabber.cpp
@@ -74,8 +74,7 @@ namespace icl{
       return data->m_buffer;
     }
 
-    OpenCVVideoGrabber::OpenCVVideoGrabber(const std::string &fileName)
-    {
+    OpenCVVideoGrabber::OpenCVVideoGrabber(const std::string &fileName) : data(new Data), mutex(Mutex::mutexTypeRecursive), updating(false){
       data->m_buffer = 0;
       data->use_video_fps = true;
       data->filename = fileName;

--- a/ICLIO/src/ICLIO/OpenCVVideoGrabber.h
+++ b/ICLIO/src/ICLIO/OpenCVVideoGrabber.h
@@ -66,7 +66,7 @@ namespace icl{
 
         /// Constructor creates a new OpenCVVideoGrabber instance
         /** @param fileName name of file to use */
-        OpenCVVideoGrabber(const std::string &fileName) ;
+        OpenCVVideoGrabber(const std::string &fileName);
 
         /// Destructor
         ~OpenCVVideoGrabber();

--- a/ICLIO/src/ICLIO/OpenCVVideoWriter.cpp
+++ b/ICLIO/src/ICLIO/OpenCVVideoWriter.cpp
@@ -42,7 +42,7 @@ namespace icl{
   namespace io{
 
     OpenCVVideoWriter::OpenCVVideoWriter(const std::string &filename, const std::string &fourcc,
-                                         double fps, Size frame_size, int frame_color) {
+                                         double fps, Size frame_size, int frame_color){
       if(File(filename).exists()){
         throw ICLException("file already exists");
       }

--- a/ICLIO/src/ICLIO/OpenCVVideoWriter.h
+++ b/ICLIO/src/ICLIO/OpenCVVideoWriter.h
@@ -75,7 +75,7 @@ namespace icl{
   	    @param frame_color currently only supported on windows 0 for greyscale else color
             **/
   	OpenCVVideoWriter(const std::string &filename, const std::string &fourcc,
-                          double fps, utils::Size frame_size, int frame_color=1) ;
+                          double fps, utils::Size frame_size, int frame_color=1);
 
   	/// Destructor
   	~OpenCVVideoWriter();

--- a/ICLIO/src/ICLIO/OptrisGrabber.cpp
+++ b/ICLIO/src/ICLIO/OptrisGrabber.cpp
@@ -171,7 +171,7 @@ namespace icl{
       }
 
 
-      std::string  init(const std::string &serialPattern, OptrisGrabber::Mode mode) {
+      std::string  init(const std::string &serialPattern, OptrisGrabber::Mode mode){
         buffer.mode = mode;
 
         FileList cfgs("/usr/share/libirimager/cali/Cali-*.xml");

--- a/ICLIO/src/ICLIO/RSBIOUtil.h
+++ b/ICLIO/src/ICLIO/RSBIOUtil.h
@@ -211,7 +211,7 @@ namespace icl{
 
 
       protected:
-      inline void null_check(const std::string &fn) const  {
+      inline void null_check(const std::string &fn) const {
         if (isNull()) throw utils::ICLException(fn + ": RSBListener is null");
       }
     };
@@ -247,7 +247,7 @@ namespace icl{
       }
 
       protected:
-      inline void null_check(const std::string &fn) const  {
+      inline void null_check(const std::string &fn) const {
         if (isNull()) throw utils::ICLException(fn + ": RSBSender is null");
       }
 

--- a/ICLIO/src/ICLIO/SharedMemoryGrabber.cpp
+++ b/ICLIO/src/ICLIO/SharedMemoryGrabber.cpp
@@ -161,7 +161,7 @@ namespace icl{
       Configurable::registerCallback(utils::function(this,&SharedMemoryGrabber::processPropertyChange));
     }
 
-    void SharedMemoryGrabber::init(const std::string &sharedMemorySegmentID) {
+    void SharedMemoryGrabber::init(const std::string &sharedMemorySegmentID){
       try{
         m_data->mem.reset(ICL_IMGBASE_STREAM_PREPEND+sharedMemorySegmentID, 0);
       } catch (ICLException &e){

--- a/ICLIO/src/ICLIO/SharedMemoryPublisher.cpp
+++ b/ICLIO/src/ICLIO/SharedMemoryPublisher.cpp
@@ -48,7 +48,7 @@ namespace icl{
       SharedMemorySegment mem;
     };
 
-    SharedMemoryPublisher::SharedMemoryPublisher(const std::string &memorySegmentName) {
+    SharedMemoryPublisher::SharedMemoryPublisher(const std::string &memorySegmentName){
       m_data = new Data;
       createPublisher(memorySegmentName);
     }
@@ -57,7 +57,7 @@ namespace icl{
       delete m_data;
     }
 
-    void SharedMemoryPublisher::createPublisher(const std::string &memorySegmentName) {
+    void SharedMemoryPublisher::createPublisher(const std::string &memorySegmentName){
       m_data->name = memorySegmentName;
       m_data->mem.reset(ICL_IMGBASE_STREAM_PREPEND + memorySegmentName);
 
@@ -79,7 +79,7 @@ namespace icl{
       std::copy(data.bytes, data.bytes+data.len,(icl8u*)m_data->mem.data());
     }
 
-    std::string SharedMemoryPublisher::getMemorySegmentName() const {
+    std::string SharedMemoryPublisher::getMemorySegmentName() const{
       return m_data->mem.getName();
     }
 

--- a/ICLIO/src/ICLIO/SharedMemoryPublisher.h
+++ b/ICLIO/src/ICLIO/SharedMemoryPublisher.h
@@ -48,13 +48,13 @@ namespace icl{
 
       /// Creates a new publisher instance
       /** If memorySegmentName is "", no connection is performed */
-      SharedMemoryPublisher(const std::string &memorySegmentName="") ;
+      SharedMemoryPublisher(const std::string &memorySegmentName="");
 
       /// Destructor
       ~SharedMemoryPublisher();
 
       /// sets the publisher to use a new segment
-      void createPublisher(const std::string &memorySegmentName="") ;
+      void createPublisher(const std::string &memorySegmentName="");
 
       /// publishs given image
       void publish(const core::ImgBase *image);
@@ -63,7 +63,7 @@ namespace icl{
       virtual void send(const core::ImgBase *image) { publish(image); }
 
       /// returns current memory segment name
-      std::string getMemorySegmentName() const ;
+      std::string getMemorySegmentName() const;
     };
   } // namespace io
 }

--- a/ICLIO/src/ICLIO/SwissRangerGrabber.cpp
+++ b/ICLIO/src/ICLIO/SwissRangerGrabber.cpp
@@ -69,7 +69,7 @@ inline int set_canon(int flag){
 namespace icl{
   namespace io{
 
-    static std::string translate_modulation_freq(ModulationFrq m) {
+    static std::string translate_modulation_freq(ModulationFrq m){
       switch(m){
 #define CASE(X) case MF_##X##MHz: return #X+str("MHz");
         CASE(40);CASE(30);CASE(21);CASE(20);CASE(19);CASE(60);
@@ -296,7 +296,7 @@ namespace icl{
     static int g_swissranger_instance_count = 0;
 
 
-    SwissRangerGrabber::SwissRangerGrabber(int serialNumber, depth bufferDepth, int pickChannel) {
+    SwissRangerGrabber::SwissRangerGrabber(int serialNumber, depth bufferDepth, int pickChannel):Grabber(){
       g_swissranger_instance_count++;
 
       if(g_swissranger_instance_count == 1){
@@ -441,7 +441,7 @@ namespace icl{
       }
     }
 
-    float SwissRangerGrabber::getMaxRangeMM(const std::string &modulationFreq) {
+    float SwissRangerGrabber::getMaxRangeMM(const std::string &modulationFreq){
       return get_max_range_mm(translate_modulation_freq(modulationFreq));
     }
 

--- a/ICLIO/src/ICLIO/SwissRangerGrabber.h
+++ b/ICLIO/src/ICLIO/SwissRangerGrabber.h
@@ -53,8 +53,7 @@ namespace icl{
       */
         ICLIO_API SwissRangerGrabber(int serialNumber=0,
                                core::depth bufferDepth=core::depth32f,
-                               int pickChannel=-1)
-        ;
+                               int pickChannel=-1);
 
         /// Destructor
         ICLIO_API ~SwissRangerGrabber();
@@ -66,7 +65,7 @@ namespace icl{
         ICLIO_API const core::ImgBase *acquireImage();
 
         /// Internally used utility function, that might be interesting elsewhere
-        ICLIO_API static float getMaxRangeMM(const std::string &modulationFreq) ;
+        ICLIO_API static float getMaxRangeMM(const std::string &modulationFreq);
 
         /// adds properties to Configurable
         ICLIO_API void addProperties();

--- a/ICLIO/src/ICLIO/V4L2Grabber.cpp
+++ b/ICLIO/src/ICLIO/V4L2Grabber.cpp
@@ -161,10 +161,10 @@ namespace icl{
           return stream.str();
         }
 
-        void errno_exception(const std::string &text) {
+        void errno_exception(const std::string &text){
           throw ICLException(text +" (deviceName: " + deviceName + " errno: "+ str(errno) +", " + strerror(errno) + ")");
         }
-        void normal_exception(const std::string &text) {
+        void normal_exception(const std::string &text){
           throw ICLException(text +" (deviceName: " + deviceName + ")");
         }
 
@@ -583,7 +583,7 @@ namespace icl{
         typedef std::map<std::string,SupportedPropertyPtr> PMap;
         PMap supportedProperties;
 
-        SupportedPropertyPtr findProperty(const std::string &name)  {
+        SupportedPropertyPtr findProperty(const std::string &name){
           PMap::const_iterator it = supportedProperties.find(name);
           //if(it == supportedProperties.end()) throw ICLException("V4L2Grabber: unknown property '" + name + "'");
           if(it == supportedProperties.end()) return SupportedPropertyPtr();

--- a/ICLIO/src/ICLIO/V4L2LoopBackOutput.cpp
+++ b/ICLIO/src/ICLIO/V4L2LoopBackOutput.cpp
@@ -143,13 +143,13 @@ namespace icl{
       }
     };
 
-    V4L2LoopBackOutput::V4L2LoopBackOutput(const std::string &device) :
+    V4L2LoopBackOutput::V4L2LoopBackOutput(const std::string &device):
       m_data(new Data){
 
       init(device);
     }
 
-    void V4L2LoopBackOutput::init(const std::string &device) {
+    void V4L2LoopBackOutput::init(const std::string &device){
       if(device.length() == 1 || device.length() == 2){
         int id = utils::parse<int>(device);
         if(id >= 0 && id <= 99){

--- a/ICLIO/src/ICLIO/V4L2LoopBackOutput.h
+++ b/ICLIO/src/ICLIO/V4L2LoopBackOutput.h
@@ -77,10 +77,10 @@ namespace icl{
       /// creates V4L2LoopBackImageOutput from given device string
       /** The device string can either be the full device-name, such as /dev/video1 or
           just an integer that specifies the device id (1 for /dev/video1 etc.) */
-      V4L2LoopBackOutput(const std::string &device) ;
+      V4L2LoopBackOutput(const std::string &device);
 
       /// initializes a the deivce
-      void init(const std::string &deviceString) ;
+      void init(const std::string &deviceString);
 
       /// actual publishing function
       virtual void send(const core::ImgBase *image);

--- a/ICLIO/src/ICLIO/VideoGrabber.cpp
+++ b/ICLIO/src/ICLIO/VideoGrabber.cpp
@@ -57,7 +57,7 @@ namespace icl{
         xine_video_port_t   *vo_port;
         xine_audio_port_t   *ao_port;
 
-        XineHandle(const std::string &filename) :
+        XineHandle(const std::string &filename):
           xine(0),stream(0),vo_port(0),ao_port(0){
           xine = xine_new();
           xine_config_load(xine,(str(xine_get_homedir())+"/.xine/config").c_str());
@@ -218,7 +218,7 @@ namespace icl{
     };
 
 
-    VideoGrabber::VideoGrabber(const std::string &filename) :
+    VideoGrabber::VideoGrabber(const std::string &filename):
       m_xine(0),m_data(0),m_params(0){
 
       if(!File(filename).exists()){

--- a/ICLIO/src/ICLIO/VideoGrabber.h
+++ b/ICLIO/src/ICLIO/VideoGrabber.h
@@ -65,7 +65,7 @@ namespace icl{
       public:
 
         /// Create video grabber with given video-file name
-        VideoGrabber(const std::string &fileName) ;
+        VideoGrabber(const std::string &fileName);
 
         /// Destructor
         ~VideoGrabber();

--- a/ICLIO/src/ICLIO/XiGrabber.cpp
+++ b/ICLIO/src/ICLIO/XiGrabber.cpp
@@ -241,7 +241,7 @@ namespace icl{
 
     };
 
-    void XiGrabber::init(int deviceID) {
+    void XiGrabber::init(int deviceID){
       if(m_data) delete m_data;
       m_data = new Data(deviceID);
 

--- a/ICLIO/src/ICLIO/ZmqGrabber.cpp
+++ b/ICLIO/src/ICLIO/ZmqGrabber.cpp
@@ -80,7 +80,7 @@ namespace icl{
     };
 
 
-    ZmqGrabber::ZmqGrabber(const std::string &host, int port) :m_data(0){
+    ZmqGrabber::ZmqGrabber(const std::string &host, int port):m_data(0){
       m_data = new Data(host,port);
     }
 

--- a/ICLMarkers/src/ICLMarkers/AdvancedMarkerGridDetector.cpp
+++ b/ICLMarkers/src/ICLMarkers/AdvancedMarkerGridDetector.cpp
@@ -39,8 +39,7 @@ namespace icl{
                                                                                const utils::Size32f &markerBounds,
                                                                                const utils::Size32f &gridBounds,
                                                                                const std::vector<int> &markerIDs,
-                                                                               const std::string &markerType)
-      {
+                                                                               const std::string &markerType):MarkerGridDetector::GridDefinition(numCells,markerIDs, markerType){
       this->markerBounds = markerBounds;
       this->gridBounds = gridBounds;
     }
@@ -172,7 +171,7 @@ namespace icl{
 
 
     const AdvancedMarkerGridDetector::Marker &
-    AdvancedMarkerGridDetector::MarkerGrid::getMarker(int id) const {
+    AdvancedMarkerGridDetector::MarkerGrid::getMarker(int id) const{
       int idx = gridDef.getIndex(id);
       if(idx < 0) throw utils::ICLException("invalid marker ID");
       return (*this)[idx];

--- a/ICLMarkers/src/ICLMarkers/AdvancedMarkerGridDetector.h
+++ b/ICLMarkers/src/ICLMarkers/AdvancedMarkerGridDetector.h
@@ -61,7 +61,7 @@ namespace icl{
                                const utils::Size32f &markerBounds,
                                const utils::Size32f &gridBounds,
                                const std::vector<int> &markerIDs=std::vector<int>(),
-                               const std::string &markerType="bch") ;
+                               const std::string &markerType="bch");
 
         /// returns internal marker-bounds value
         const utils::Size32f &getMarkerBounds() const {
@@ -190,7 +190,7 @@ namespace icl{
         }
 
         /// returns the marker for the given ID
-        const Marker &getMarker(int id) const ;
+        const Marker &getMarker(int id) const;
 
         /// visualizes the whole grid (i.e. each marker)
         utils::VisualizationDescription vis() const;

--- a/ICLMarkers/src/ICLMarkers/BCHCode.cpp
+++ b/ICLMarkers/src/ICLMarkers/BCHCode.cpp
@@ -564,7 +564,7 @@ namespace icl {
     }
 
 
-    static BCHCode code_from_image(const Img8u &image, bool useROI) {
+    static BCHCode code_from_image(const Img8u &image, bool useROI){
       BCHCode code(0);
       ICLASSERT_THROW(image.getChannels(), ICLException("code_from_image(const Img8u&,bool): input image has not channels"));
       if(useROI){
@@ -583,7 +583,7 @@ namespace icl {
       return code;
     }
 
-    DecodedBCHCode BCHCoder::decode(const Img8u &image, bool useROI) {
+    DecodedBCHCode BCHCoder::decode(const Img8u &image, bool useROI){
       return decode(code_from_image(image,useROI));
     }
 
@@ -598,7 +598,7 @@ namespace icl {
       return out;
     }
 
-    DecodedBCHCode2D BCHCoder::decode2D(const Img8u &image, int maxID, bool useROI) {
+    DecodedBCHCode2D BCHCoder::decode2D(const Img8u &image, int maxID, bool useROI){
       BCHCode last = code_from_image(image,useROI);
       DecodedBCHCode2D best = decode(last);
       if(best.id > maxID){

--- a/ICLMarkers/src/ICLMarkers/BCHCode.h
+++ b/ICLMarkers/src/ICLMarkers/BCHCode.h
@@ -131,7 +131,7 @@ namespace icl{
       DecodedBCHCode decode(const icl8u data[36]);
 
       /// decodes given (correctly oriented) core::Img8u (optionally using its ROI or not)
-      DecodedBCHCode decode(const core::Img8u &image, bool useROI=true) ;
+      DecodedBCHCode decode(const core::Img8u &image, bool useROI=true);
 
       /// decodes given core::Img8u (optionally using its ROI or not)
       /** Internally, this methods checks for all 4 possible image rotations and returns
@@ -149,7 +149,7 @@ namespace icl{
 
           <b>please note</b> that it's best to use the first N IDs if you want to use N markers
           */
-      DecodedBCHCode2D decode2D(const core::Img8u &image, int maxID=4095, bool useROI=true) ;
+      DecodedBCHCode2D decode2D(const core::Img8u &image, int maxID=4095, bool useROI=true);
 
     };
   } // namespace markers

--- a/ICLMarkers/src/ICLMarkers/FiducialDetector.cpp
+++ b/ICLMarkers/src/ICLMarkers/FiducialDetector.cpp
@@ -104,7 +104,7 @@ namespace icl{
     FiducialDetector::FiducialDetector(const std::string &plugin,
                                        const Any &markersToLoad,
                                        const ParamList &params,
-                                       const Camera *camera) :
+                                       const Camera *camera):
       data(new Data){
       data->plugin = 0;
       data->plugintype = plugin;
@@ -152,7 +152,7 @@ namespace icl{
       data->plugin->camera = data->camera.get();
     }
 
-    const Camera &FiducialDetector::getCamera() const {
+    const Camera &FiducialDetector::getCamera() const{
       if(!data->camera) throw ICLException("FiducialDetector::getCamera: camera has not been set");
       return *data->camera;
     }
@@ -161,7 +161,7 @@ namespace icl{
       return data->plugintype;
     }
 
-    void  FiducialDetector::loadMarkers(const Any &which, const ParamList &params) {
+    void  FiducialDetector::loadMarkers(const Any &which, const ParamList &params){
       data->plugin->addOrRemoveMarkers(true,which,params);
     }
 
@@ -169,7 +169,7 @@ namespace icl{
       data->plugin->addOrRemoveMarkers(false,which,ParamList());
     }
 
-    const std::vector<Fiducial> &FiducialDetector::detect(const ImgBase *image) {
+    const std::vector<Fiducial> &FiducialDetector::detect(const ImgBase *image){
       ICLASSERT_THROW(image,ICLException("FiducialDetector::detect: image was 0"));
 
       data->iis.input = const_cast<ImgBase*>(image);
@@ -203,7 +203,7 @@ namespace icl{
       }
     }
 
-    const ImgBase *FiducialDetector::getIntermediateImage(const std::string &name) const {
+    const ImgBase *FiducialDetector::getIntermediateImage(const std::string &name) const{
       if(name == "input") return data->iis.input;
       if(name == "pp") return data->iis.pp;
       return data->plugin->getIntermediateImage(name);

--- a/ICLMarkers/src/ICLMarkers/FiducialDetector.h
+++ b/ICLMarkers/src/ICLMarkers/FiducialDetector.h
@@ -98,7 +98,7 @@ namespace icl{
       FiducialDetector(const std::string &plugin="bch",
                        const utils::Any &markersToLoad=utils::Any(),
                        const utils::ParamList &params=utils::ParamList(),
-                       const geom::Camera *camera=0) ;
+                       const geom::Camera *camera=0);
 
       /// Destructor
       virtual ~FiducialDetector();
@@ -114,7 +114,7 @@ namespace icl{
       void setCamera(const geom::Camera &camera);
 
       /// returns the current camera (or throws an exception if no camera is available)
-      const geom::Camera &getCamera() const ;
+      const geom::Camera &getCamera() const;
 
       /// loads markers according to the current plugin type
       /** - "bch":\n
@@ -143,7 +143,7 @@ namespace icl{
             add all markers. Actually if you load a marker ID x, also the inverted marker
             (that has a white root-region) with ID -x is added.
       */
-      void loadMarkers(const utils::Any &which, const utils::ParamList &params=utils::ParamList()) ;
+      void loadMarkers(const utils::Any &which, const utils::ParamList &params=utils::ParamList());
 
 
       /// unloads all already defined markers
@@ -156,7 +156,7 @@ namespace icl{
           are converted to depth8u internally. Usually, your
           plugin will use gray images as input. You can query this information
           by calling getPropertyValue("preferred image type") */
-      const std::vector<Fiducial> &detect(const core::ImgBase *image) ;
+      const std::vector<Fiducial> &detect(const core::ImgBase *image);
 
       /// returns the list of supported features
       Fiducial::FeatureSet getFeatures() const;
@@ -172,7 +172,7 @@ namespace icl{
       /** If no image is associated with this name, an exception is thrown. Note,
           the image might be associated, but still be null, in particular if detect
           was not called one before */
-      const core::ImgBase *getIntermediateImage(const std::string &name) const ;
+      const core::ImgBase *getIntermediateImage(const std::string &name) const;
 
 
       /// creates an image of a given markers

--- a/ICLMarkers/src/ICLMarkers/FiducialDetectorPlugin.h
+++ b/ICLMarkers/src/ICLMarkers/FiducialDetectorPlugin.h
@@ -150,7 +150,7 @@ namespace icl{
           intermediate images with names "input" and "pp" must not be checked here. But in
           turn, these two names must not be used for intermediate image names in the
           plugin implementation */
-      virtual const core::ImgBase *getIntermediateImage(const std::string &name) const {
+      virtual const core::ImgBase *getIntermediateImage(const std::string &name) const{
         throw utils::ICLException("FiducialDetectorPlugin: no intermediate image is associated with givne name '" + name + "'");
         return 0;
       }

--- a/ICLMarkers/src/ICLMarkers/FiducialDetectorPluginForQuads.cpp
+++ b/ICLMarkers/src/ICLMarkers/FiducialDetectorPluginForQuads.cpp
@@ -231,7 +231,7 @@ namespace icl{
     }
 
     const ImgBase *FiducialDetectorPluginForQuads::getIntermediateImage(const std::string &name)
-      const {
+      const{
       if(name != "binary") return FiducialDetectorPlugin::getIntermediateImage(name);
       return &data->quadd.getLastBinaryImage();
     }

--- a/ICLMarkers/src/ICLMarkers/FiducialDetectorPluginForQuads.h
+++ b/ICLMarkers/src/ICLMarkers/FiducialDetectorPluginForQuads.h
@@ -90,7 +90,7 @@ namespace icl{
 
       /// returns the intermediate image, that is associated with the given name
       /** @see getIntermediateImageNames for more details */
-      const core::ImgBase *getIntermediateImage(const std::string &name) const ;
+      const core::ImgBase *getIntermediateImage(const std::string &name) const;
 
       /// this method is called before the patch classification loop is started
       /** this function can be used to avoid property extraction at runtime. Usually,

--- a/ICLMarkers/src/ICLMarkers/MarkerGridDetector.cpp
+++ b/ICLMarkers/src/ICLMarkers/MarkerGridDetector.cpp
@@ -44,8 +44,7 @@ namespace  icl{
 
     MarkerGridDetector::GridDefinition::GridDefinition(const utils::Size &numCells,
                                                        const std::vector<int> &markerIDs,
-                                                       const std::string &markerType)
-       :
+                                                       const std::string &markerType) :
       numCells(numCells),ids(markerIDs),markerType(markerType){
 
       int n = getDim();
@@ -137,8 +136,7 @@ namespace  icl{
       return m_data->def;
     }
 
-    const MarkerGridDetector::Result &MarkerGridDetector::detect(const core::ImgBase *image)
-      {
+    const MarkerGridDetector::Result &MarkerGridDetector::detect(const core::ImgBase *image){
       if(isNull()){
         throw utils::ICLException("MarkerGridDetector::detect: instance not yet initialized");
       }

--- a/ICLMarkers/src/ICLMarkers/MarkerGridDetector.h
+++ b/ICLMarkers/src/ICLMarkers/MarkerGridDetector.h
@@ -69,7 +69,7 @@ namespace icl{
         /// constructor with given parameters
         GridDefinition(const utils::Size &numCells,
                        const std::vector<int> &markerIDs=std::vector<int>(),
-                       const std::string &markerType="bch") ;
+                       const std::string &markerType="bch");
 
         /// returns the grid x/y index for a given marker ID
         /** If the id is not contained in the grid, (-1,-1) is returned */
@@ -126,7 +126,7 @@ namespace icl{
 
 
       /// actual detection function
-      const Result &detect(const core::ImgBase *image) ;
+      const Result &detect(const core::ImgBase *image);
 
       /// returns whether the instance has already been already initialized
       bool isNull() const;

--- a/ICLMarkers/src/ICLMarkers/MultiCamFiducialDetector.cpp
+++ b/ICLMarkers/src/ICLMarkers/MultiCamFiducialDetector.cpp
@@ -76,7 +76,7 @@ namespace icl{
                                                        const ParamList &params,
                                                        const std::vector<Camera*> &cams,
                                                        bool syncProperties,
-                                                       bool deepCopyCams) {
+                                                       bool deepCopyCams):m_data(0){
       init(pluginType,markersToLoad,params,cams,syncProperties,deepCopyCams);
     }
 
@@ -86,7 +86,7 @@ namespace icl{
                                         const ParamList &params,
                                         const std::vector<Camera*> &cams,
                                         bool syncProperties,
-                                        bool deepCopyCams) {
+                                        bool deepCopyCams){
       if(m_data) delete m_data;
       m_data = new Data;
 
@@ -115,7 +115,7 @@ namespace icl{
 
 
     const std::vector<MultiCamFiducial> &MultiCamFiducialDetector::detect(const std::vector<const ImgBase*> &images,
-                                                                          int minCamsFound) {
+                                                                          int minCamsFound){
       ICLASSERT_THROW(m_data, ICLException(str(__FUNCTION__)+": this is null"));
       ICLASSERT_THROW(m_data->detectors.size() == images.size(),
                       ICLException(str(__FUNCTION__)+ ": given image count is wrong (got "
@@ -178,7 +178,7 @@ namespace icl{
       return *m_data->detectors[idx];
     }
 
-    void MultiCamFiducialDetector::loadMarkers(const Any &which, const ParamList &params) {
+    void MultiCamFiducialDetector::loadMarkers(const Any &which, const ParamList &params){
       ICLASSERT_THROW(m_data, ICLException(str(__FUNCTION__)+": this is null"));
       for(int i=0;i<getNumCameras();++i){
         m_data->detectors[i]->loadMarkers(which,params);
@@ -209,7 +209,7 @@ namespace icl{
       return parse<int>(name.substr(4));
     }
 
-    const ImgBase *MultiCamFiducialDetector::getIntermediateImage(const std::string &name) const {
+    const ImgBase *MultiCamFiducialDetector::getIntermediateImage(const std::string &name) const{
       ICLASSERT_THROW(m_data, ICLException(str(__FUNCTION__)+": this is null"));
       int idx = parse<int>(name.substr(4));
       if(idx >= 0 && idx < getNumCameras()){

--- a/ICLMarkers/src/ICLMarkers/MultiCamFiducialDetector.h
+++ b/ICLMarkers/src/ICLMarkers/MultiCamFiducialDetector.h
@@ -79,7 +79,7 @@ namespace icl{
                                const utils::ParamList &params,
                                const std::vector<geom::Camera*> &cams,
                                bool syncProperties=true,
-                               bool deepCopyCams=false) ;
+                               bool deepCopyCams=false);
 
       /// (re-)initializes the detector with given parameters
       /** @param pluginType this option directly passed to all internal 2D FiducialDetector instances
@@ -100,13 +100,13 @@ namespace icl{
                 const utils::ParamList &params,
                 const std::vector<geom::Camera*> &cams,
                 bool syncProperties=true,
-                bool deepCopyCams=false) ;
+                bool deepCopyCams=false);
 
 
       /// detects fiducials in all images and returns the combined results
       /** Please note, that images[i] must correspond to cams[i] in the constructor/init method*/
       const std::vector<MultiCamFiducial> &detect(const std::vector<const core::ImgBase*> &images,
-                                                  int minCamsFound=1) ;
+                                                  int minCamsFound=1);
 
       /// returns the internal number of cameras
       int getNumCameras() const;
@@ -118,7 +118,7 @@ namespace icl{
       FiducialDetector &getFiducialDetector(int idx);
 
       /// loads additional markers (passed to all 2D detectors)
-      void loadMarkers(const utils::Any &which, const utils::ParamList &params) ;
+      void loadMarkers(const utils::Any &which, const utils::ParamList &params);
 
       /// unloads markers (passed to all 2D detectors)
       void unloadMarkers(const utils::Any &which);
@@ -142,7 +142,7 @@ namespace icl{
       std::string getIntermediateImageNames() const;
 
       /// returns a named intermeted image
-      const core::ImgBase *getIntermediateImage(const std::string &name) const ;
+      const core::ImgBase *getIntermediateImage(const std::string &name) const;
 
       /// extract the current camera from the given intermediate image name
       static int getCameraIDFromIntermediteImageName(const std::string &name);

--- a/ICLMarkers/src/ICLMarkers/QuadDetector.cpp
+++ b/ICLMarkers/src/ICLMarkers/QuadDetector.cpp
@@ -56,7 +56,7 @@ namespace icl {
   namespace markers {
 
     static void optimize_edges(std::vector<Point32f> &e4,
-                               const std::vector<Point> &boundary) ;
+                               const std::vector<Point> &boundary);
 
     class QuadDetector::Data {
 
@@ -781,7 +781,7 @@ namespace icl {
     }
 
 #if 0
-    static StraightLine2D approx_line(const std::vector<Point32f> &ps)  {
+    static StraightLine2D approx_line(const std::vector<Point32f> &ps) {
       int nPts = ps.size();
       if(nPts < 2) throw 2;
       float avgX = 0;
@@ -817,8 +817,7 @@ namespace icl {
     }
 #endif
 
-    static StraightLine2D fit_line(float x, float y, float xx, float xy, float yy)
-       {
+    static StraightLine2D fit_line(float x, float y, float xx, float xy, float yy) {
       float sxx = xx - x * x;
       float syy = yy - y * y;
       float sxy = xy - x * y;
@@ -837,7 +836,7 @@ namespace icl {
 
 
     void optimize_edges(std::vector<Point32f> &e4,
-                        const std::vector<Point> &boundary)  {
+                        const std::vector<Point> &boundary) {
       int num = boundary.size();
       int i0 = (int) (std::find(boundary.begin(), boundary.end(), Point(e4[0]))
                       - boundary.begin());

--- a/ICLMarkers/src/ICLMarkers/TwoLevelRegionStructure.cpp
+++ b/ICLMarkers/src/ICLMarkers/TwoLevelRegionStructure.cpp
@@ -38,7 +38,7 @@ using namespace icl::cv;
 
 namespace icl{
   namespace markers{
-    TwoLevelRegionStructure::TwoLevelRegionStructure(const std::string &code) {
+    TwoLevelRegionStructure::TwoLevelRegionStructure(const std::string &code) : color(0), code(code){
       if(code.size() < 3) throw ICLException("TwoLevelRegionStructure(code): error parsing code " + code + "(code too short)");
       int i=0;
       if(code[i] == 'b' || code[i] == 'w'){

--- a/ICLMarkers/src/ICLMarkers/TwoLevelRegionStructure.h
+++ b/ICLMarkers/src/ICLMarkers/TwoLevelRegionStructure.h
@@ -91,7 +91,7 @@ namespace icl{
           the children counts are sorted for easier comparison with an actual
           region structure whose root-region is passed to the virtual match method.
       */
-      TwoLevelRegionStructure(const std::string &code) ;
+      TwoLevelRegionStructure(const std::string &code);
 
       /// match implementation
       virtual bool match(const cv::ImageRegion &r) const;

--- a/ICLMath/src/ICLMath/DynMatrix.cpp
+++ b/ICLMath/src/ICLMath/DynMatrix.cpp
@@ -82,7 +82,7 @@ namespace icl{
 
 
     template<class T>
-    DynMatrix<T> DynMatrix<T>::inv() const {
+    DynMatrix<T> DynMatrix<T>::inv() const{
       double detVal = det();
       if(!detVal) throw SingularMatrixException("Determinant was 0 -> (matrix is singular to machine precision)");
       detVal = 1.0/detVal;
@@ -102,9 +102,9 @@ namespace icl{
     }
 
     template<class T>
-    T DynMatrix<T>::det() const {
+    T DynMatrix<T>::det() const{
       unsigned int order = cols();
-      if(order != rows()) throw(InvalidMatrixDimensionException("Determinant can only be calculated on squared matrices"));
+      if(order != rows()) throw InvalidMatrixDimensionException("Determinant can only be calculated on squared matrices");
 
       switch(order){
         case 0: throw(InvalidMatrixDimensionException("Matrix order must be > 0"));
@@ -145,8 +145,7 @@ namespace icl{
     }
 
     template<class T>
-    void DynMatrix<T>::decompose_QR(DynMatrix<T> &Q, DynMatrix<T> &R) const
-           {
+    void DynMatrix<T>::decompose_QR(DynMatrix<T> &Q, DynMatrix<T> &R) const {
       DynMatrix<T> A = *this; // Working copy
       DynMatrix<T> a(1,rows()), q(1,rows());
 
@@ -176,8 +175,7 @@ namespace icl{
     }
 
     template<class T>
-    void DynMatrix<T>::decompose_RQ(DynMatrix<T> &R, DynMatrix<T> &Q) const
-           {
+    void DynMatrix<T>::decompose_RQ(DynMatrix<T> &R, DynMatrix<T> &Q) const {
      // first reverse the rows of A and transpose it
       DynMatrix<T> A_(rows(),cols());
       for (unsigned int i = 0; i<rows(); i++){
@@ -272,7 +270,7 @@ namespace icl{
     }
 
     template<class T>
-    DynMatrix<T> DynMatrix<T>::solve_upper_triangular(const DynMatrix &b) const {
+    DynMatrix<T> DynMatrix<T>::solve_upper_triangular(const DynMatrix &b) const{
       const DynMatrix &M = *this;
       ICLASSERT_THROW(M.cols() == M.rows(), ICLException("solve_upper_triangular only works for squared matrices"));
       int m = M.cols();
@@ -286,7 +284,7 @@ namespace icl{
     }
 
     template<class T>
-    DynMatrix<T> DynMatrix<T>::solve_lower_triangular(const DynMatrix &b) const {
+    DynMatrix<T> DynMatrix<T>::solve_lower_triangular(const DynMatrix &b) const{
       const DynMatrix &M = *this;
       ICLASSERT_THROW(M.cols() == M.rows(), ICLException("solve_lower_triangular: only works for squared matrices"));
       int m = M.cols();
@@ -300,7 +298,7 @@ namespace icl{
     }
 
     template<class T>
-    DynMatrix<T> DynMatrix<T>::solve(const DynMatrix &b, const std::string &method ,T zeroThreshold) {
+    DynMatrix<T> DynMatrix<T>::solve(const DynMatrix &b, const std::string &method ,T zeroThreshold){
       ICLASSERT_THROW(rows() == b.rows(), InvalidMatrixDimensionException("DynMatrix::solve (Mx=b -> x=M^(-1)b needs M.rows == b.rows)"));
       if(method == "lu"){
         DynMatrix<T> L,U;
@@ -320,8 +318,7 @@ namespace icl{
 
 
     template<class T>
-    DynMatrix<T> DynMatrix<T>::pinv(bool useSVD, T zeroThreshold) const
-      {
+    DynMatrix<T> DynMatrix<T>::pinv(bool useSVD, T zeroThreshold) const{
       if(useSVD){
         DynMatrix<T> U,s,V;
         try{
@@ -349,15 +346,13 @@ namespace icl{
 
     // fallback
     template<class T>
-    DynMatrix<T> DynMatrix<T>::big_matrix_pinv(T zeroThreshold) const
-      {
+    DynMatrix<T> DynMatrix<T>::big_matrix_pinv(T zeroThreshold) const{
       return pinv( true, zeroThreshold );
     }
 
   #ifdef ICL_HAVE_MKL
     template<class T>
-      DynMatrix<T> DynMatrix<T>::big_matrix_pinv(T zeroThreshold, GESDD gesdd, CBLAS_GEMM cblas_gemm) const
-      {
+      DynMatrix<T> DynMatrix<T>::big_matrix_pinv(T zeroThreshold, GESDD gesdd, CBLAS_GEMM cblas_gemm) const{
 
       // create a copy of source matrix, because GESDD is destroying the input matrix
       DynMatrix<T> matrixCopy( *this );
@@ -424,13 +419,11 @@ namespace icl{
     }
 
     template<>
-    ICLMath_API DynMatrix<float> DynMatrix<float>::big_matrix_pinv(float zeroThreshold) const
-      {
+    ICLMath_API DynMatrix<float> DynMatrix<float>::big_matrix_pinv(float zeroThreshold) const{
       return big_matrix_pinv(zeroThreshold,sgesdd,cblas_sgemm);
     }
     template<>
-    ICLMath_API DynMatrix<double> DynMatrix<double>::big_matrix_pinv(double zeroThreshold) const
-      {
+    ICLMath_API DynMatrix<double> DynMatrix<double>::big_matrix_pinv(double zeroThreshold) const{
       return big_matrix_pinv(zeroThreshold,dgesdd,cblas_dgemm);
     }
   #endif
@@ -648,7 +641,7 @@ namespace icl{
   #endif
 
     template<class T>
-    void DynMatrix<T>::eigen(DynMatrix<T> &eigenvectors, DynMatrix<T> &eigenvalues) const {
+    void DynMatrix<T>::eigen(DynMatrix<T> &eigenvectors, DynMatrix<T> &eigenvalues) const{
       ICLASSERT_THROW(cols() == rows(), InvalidMatrixDimensionException("find eigenvectors: input matrix a is not a square-matrix"));
       const int n = cols();
       eigenvalues.setBounds(1,n);
@@ -658,14 +651,14 @@ namespace icl{
     }
 
     template<class T>
-    void DynMatrix<T>::svd(DynMatrix &V, DynMatrix &s, DynMatrix &U) const {
+    void DynMatrix<T>::svd(DynMatrix &V, DynMatrix &s, DynMatrix &U) const{
       svd_dyn<T>(*this,V,s,U);
     }
 
 
 #ifdef ICL_HAVE_IPP
   #define DYN_MATRIX_INV(T, ippFunc) \
-    template<> ICLMath_API DynMatrix<T> DynMatrix<T>::inv() const { \
+    template<> ICLMath_API DynMatrix<T> DynMatrix<T>::inv() const{ \
       if(this->cols() != this->rows()){ \
         throw InvalidMatrixDimensionException("inverse matrix can only be calculated on square matrices"); \
       } \
@@ -683,7 +676,7 @@ namespace icl{
     }
 
   #define DYN_MATRIX_DET(T, ippFunc) \
-    template<> ICLMath_API T DynMatrix<T>::det() const { \
+    template<> ICLMath_API T DynMatrix<T>::det() const{ \
       if(this->cols() != this->rows()){ \
         throw InvalidMatrixDimensionException("matrix determinant can only be calculated on square matrices"); \
       } \
@@ -706,47 +699,45 @@ namespace icl{
     #undef DYN_MATRIX_INV
     #undef DYN_MATRIX_DET
 #else
-    template ICLMath_API DynMatrix<float> DynMatrix<float>::inv()const ;
-    template ICLMath_API DynMatrix<double> DynMatrix<double>::inv()const ;
+    template ICLMath_API DynMatrix<float> DynMatrix<float>::inv()const;
+    template ICLMath_API DynMatrix<double> DynMatrix<double>::inv()const;
 
-    template ICLMath_API float DynMatrix<float>::det()const ;
-    template ICLMath_API double DynMatrix<double>::det()const ;
+    template ICLMath_API float DynMatrix<float>::det()const;
+    template ICLMath_API double DynMatrix<double>::det()const;
 #endif
 
 
-    template ICLMath_API void DynMatrix<float>::svd(DynMatrix<float>&, DynMatrix<float>&, DynMatrix<float>&) const ;
-    template ICLMath_API void DynMatrix<double>::svd(DynMatrix<double>&, DynMatrix<double>&, DynMatrix<double>&) const ;
+    template ICLMath_API void DynMatrix<float>::svd(DynMatrix<float>&, DynMatrix<float>&, DynMatrix<float>&) const;
+    template ICLMath_API void DynMatrix<double>::svd(DynMatrix<double>&, DynMatrix<double>&, DynMatrix<double>&) const;
 
-    template ICLMath_API void DynMatrix<float>::eigen(DynMatrix<float>&, DynMatrix<float>&) const ;
-    template ICLMath_API void DynMatrix<double>::eigen(DynMatrix<double>&, DynMatrix<double>&) const ;
+    template ICLMath_API void DynMatrix<float>::eigen(DynMatrix<float>&, DynMatrix<float>&) const;
+    template ICLMath_API void DynMatrix<double>::eigen(DynMatrix<double>&, DynMatrix<double>&) const;
 
-    template ICLMath_API void DynMatrix<float>::decompose_QR(DynMatrix<float> &Q, DynMatrix<float> &R) const
-      ;
-    template ICLMath_API void DynMatrix<double>::decompose_QR(DynMatrix<double> &Q, DynMatrix<double> &R) const
-      ;
+    template ICLMath_API void DynMatrix<float>::decompose_QR(DynMatrix<float> &Q, DynMatrix<float> &R) const;
+    template ICLMath_API void DynMatrix<double>::decompose_QR(DynMatrix<double> &Q, DynMatrix<double> &R) const;
 
-    template ICLMath_API void DynMatrix<float>::decompose_RQ(DynMatrix<float> &R, DynMatrix<float> &Q) const
-      ;
-    template ICLMath_API void DynMatrix<double>::decompose_RQ(DynMatrix<double> &R, DynMatrix<double> &Q) const
-      ;
+    template ICLMath_API void DynMatrix<float>::decompose_RQ(DynMatrix<float> &R, DynMatrix<float> &Q) const;
+    template ICLMath_API void DynMatrix<double>::decompose_RQ(DynMatrix<double> &R, DynMatrix<double> &Q) const;
 
     template ICLMath_API void DynMatrix<float>::decompose_LU(DynMatrix<float> &L, DynMatrix<float> &U, float zeroThreshold) const;
     template ICLMath_API void DynMatrix<double>::decompose_LU(DynMatrix<double> &L, DynMatrix<double> &U, double zeroThreshold) const;
 
-    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_upper_triangular(const DynMatrix<float> &b) const;
-    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_upper_triangular(const DynMatrix<double> &b) const;
+    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_upper_triangular(const DynMatrix<float> &b)
+      const;
+    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_upper_triangular(const DynMatrix<double> &b)
+      const;
 
-    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_lower_triangular(const DynMatrix<float> &b) const;
-    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_lower_triangular(const DynMatrix<double> &b) const;
+    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_lower_triangular(const DynMatrix<float> &b)
+      const;
+    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_lower_triangular(const DynMatrix<double> &b)
+      const;
 
     template ICLMath_API DynMatrix<float> DynMatrix<float>::solve(const DynMatrix<float> &b, const std::string &method, float zeroThreshold);
     template ICLMath_API DynMatrix<double> DynMatrix<double>::solve(const DynMatrix<double> &b, const std::string &method, double zeroThreshold);
 
 
-    template ICLMath_API DynMatrix<float> DynMatrix<float>::pinv(bool, float) const
-      ;
-    template ICLMath_API DynMatrix<double> DynMatrix<double>::pinv(bool, double) const
-      ;
+    template ICLMath_API DynMatrix<float> DynMatrix<float>::pinv(bool, float) const;
+    template ICLMath_API DynMatrix<double> DynMatrix<double>::pinv(bool, double) const;
 
     template<class T>
     std::ostream &operator<<(std::ostream &s,const DynMatrix<T> &m){
@@ -801,7 +792,7 @@ namespace icl{
   #undef X
 
     template<class T>
-    DynMatrix<T> DynMatrix<T>::loadCSV(const std::string &filename) {
+    DynMatrix<T> DynMatrix<T>::loadCSV(const std::string &filename){
       std::ifstream s(filename.c_str());
       if(!s.good()) throw ICLException("DynMatrix::loadCSV: invalid filename ' "+ filename +'\'');
 
@@ -829,7 +820,7 @@ namespace icl{
     /// writes the current matrix to a csv file
     /** supported types T are all icl8u, icl16s, icl32s, icl32f, icl64f */
     template<class T>
-    void DynMatrix<T>::saveCSV(const std::string &filename) {
+    void DynMatrix<T>::saveCSV(const std::string &filename){
       std::ofstream s(filename.c_str());
       if(!s.good()) throw ICLException("DynMatrix::saveCSV:");
       for(unsigned int y=0;y<rows();++y){
@@ -842,8 +833,8 @@ namespace icl{
 
 
   #define ICL_INSTANTIATE_DEPTH(D)                                        \
-    template ICLMath_API DynMatrix<icl##D> DynMatrix<icl##D>::loadCSV(const std::string &filename) ; \
-    template ICLMath_API void DynMatrix<icl##D>::saveCSV(const std::string&) ;
+    template ICLMath_API DynMatrix<icl##D> DynMatrix<icl##D>::loadCSV(const std::string &filename); \
+    template ICLMath_API void DynMatrix<icl##D>::saveCSV(const std::string&);
     ICL_INSTANTIATE_ALL_DEPTHS;
   #undef ICL_INSTANTIATE_DEPTH
   } // namespace math

--- a/ICLMath/src/ICLMath/DynMatrix.cpp
+++ b/ICLMath/src/ICLMath/DynMatrix.cpp
@@ -722,15 +722,11 @@ namespace icl{
     template ICLMath_API void DynMatrix<float>::decompose_LU(DynMatrix<float> &L, DynMatrix<float> &U, float zeroThreshold) const;
     template ICLMath_API void DynMatrix<double>::decompose_LU(DynMatrix<double> &L, DynMatrix<double> &U, double zeroThreshold) const;
 
-    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_upper_triangular(const DynMatrix<float> &b)
-      const;
-    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_upper_triangular(const DynMatrix<double> &b)
-      const;
+    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_upper_triangular(const DynMatrix<float> &b) const;
+    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_upper_triangular(const DynMatrix<double> &b) const;
 
-    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_lower_triangular(const DynMatrix<float> &b)
-      const;
-    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_lower_triangular(const DynMatrix<double> &b)
-      const;
+    template ICLMath_API DynMatrix<float> DynMatrix<float>::solve_lower_triangular(const DynMatrix<float> &b) const;
+    template ICLMath_API DynMatrix<double> DynMatrix<double>::solve_lower_triangular(const DynMatrix<double> &b) const;
 
     template ICLMath_API DynMatrix<float> DynMatrix<float>::solve(const DynMatrix<float> &b, const std::string &method, float zeroThreshold);
     template ICLMath_API DynMatrix<double> DynMatrix<double>::solve(const DynMatrix<double> &b, const std::string &method, double zeroThreshold);

--- a/ICLMath/src/ICLMath/DynMatrix.h
+++ b/ICLMath/src/ICLMath/DynMatrix.h
@@ -91,7 +91,7 @@ namespace icl{
       inline DynMatrix():m_rows(0),m_cols(0),m_data(0),m_ownData(true){}
 
       /// Create a dyn matrix with given dimensions (and optional initialValue)
-      inline DynMatrix(unsigned int cols,unsigned int rows,const  T &initValue=0)  :
+      inline DynMatrix(unsigned int cols,unsigned int rows,const  T &initValue=0) :
       m_rows(rows),m_cols(cols),m_ownData(true){
         if(!dim()) throw InvalidMatrixDimensionException("matrix dimensions must be > 0");
         m_data = new T[cols*rows];
@@ -101,7 +101,7 @@ namespace icl{
       /// Create a matrix with given data
       /** Data can be wrapped deeply or shallowly. If the latter is true, given data pointer
           will not be released in the destructor*/
-      inline DynMatrix(unsigned int cols,unsigned int rows, T *data, bool deepCopy=true)  :
+      inline DynMatrix(unsigned int cols,unsigned int rows, T *data, bool deepCopy=true) :
         m_rows(rows),m_cols(cols),m_ownData(deepCopy){
         if(!dim()) throw InvalidMatrixDimensionException("matrix dimensions must be > 0");
         if(deepCopy){
@@ -113,7 +113,7 @@ namespace icl{
       }
 
       /// Create a matrix with given data (const version: deepCopy only)
-      inline DynMatrix(unsigned int cols,unsigned int rows,const T *data)  :
+      inline DynMatrix(unsigned int cols,unsigned int rows,const T *data) :
         m_rows(rows),m_cols(cols),m_ownData(true){
         if(!dim()) throw InvalidMatrixDimensionException("matrix dimensions must be > 0");
         m_data = new T[dim()];
@@ -137,11 +137,11 @@ namespace icl{
           Each row of the CSV file becomes a matrix row. The column delimiter is ','
           Rows, that begin with '#' or with ' ' or that have no length are ignored
       */
-      static DynMatrix<T> loadCSV(const std::string &filename) ;
+      static DynMatrix<T> loadCSV(const std::string &filename);
 
       /// writes the current matrix to a csv file
       /** supported types T are all icl8u, icl16s, icl32s, icl32f, icl64f */
-      void saveCSV(const std::string &filename) ;
+      void saveCSV(const std::string &filename);
 
       /// returns with this matrix has a valid data pointer
       inline bool isNull() const { return !m_data; }
@@ -176,7 +176,7 @@ namespace icl{
       }
 
       /// resets matrix dimensions
-      inline void setBounds(unsigned int cols, unsigned int rows, bool holdContent=false, const T &initializer=0) {
+      inline void setBounds(unsigned int cols, unsigned int rows, bool holdContent=false, const T &initializer=0){
         if((int)cols == m_cols && (int)rows==m_rows) return;
         if(cols*rows == 0) throw InvalidMatrixDimensionException("matrix dimensions must be > 0");
         DynMatrix M(cols,rows,initializer);
@@ -256,7 +256,7 @@ namespace icl{
       }
 
       /// Matrix multiplication (in source destination fashion) [IPP-Supported]
-      inline DynMatrix &mult(const DynMatrix &m, DynMatrix &dst) const {
+      inline DynMatrix &mult(const DynMatrix &m, DynMatrix &dst) const{
         if( cols() != m.rows() ) throw IncompatibleMatrixDimensionException("A*B : cols(A) must be rows(B)");
         dst.setBounds(m.cols(),rows());
         for(unsigned int c=0;c<dst.cols();++c){
@@ -268,7 +268,7 @@ namespace icl{
       }
 
       /// Elementwise matrix multiplication (in source destination fashion) [IPP-Supported]
-      inline DynMatrix &elementwise_mult(const DynMatrix &m, DynMatrix &dst) const {
+      inline DynMatrix &elementwise_mult(const DynMatrix &m, DynMatrix &dst) const{
         if((m.cols() != cols()) || (m.rows() != rows())) throw IncompatibleMatrixDimensionException("A.*B dimension mismatch");
         dst.setBounds(cols(),rows());
         for(unsigned int i=0;i<dim();++i){
@@ -278,13 +278,13 @@ namespace icl{
       }
 
       /// Elementwise matrix multiplication (without destination matrix) [IPP-Supported]
-      inline DynMatrix elementwise_mult(const DynMatrix &m) const {
+      inline DynMatrix elementwise_mult(const DynMatrix &m) const{
         DynMatrix dst(cols(),rows());
         return elementwise_mult(m,dst);
       }
 
       /// Elementwise division (in source destination fashion) [IPP-Supported]
-      inline DynMatrix &elementwise_div(const DynMatrix &m, DynMatrix &dst) const {
+      inline DynMatrix &elementwise_div(const DynMatrix &m, DynMatrix &dst) const{
         if((m.cols() != cols()) || (m.rows() != rows())) throw IncompatibleMatrixDimensionException("A./B dimension mismatch");
         dst.setBounds(cols(),rows());
         for(int i=0;i<dim();++i){
@@ -294,7 +294,7 @@ namespace icl{
       }
 
       /// Elementwise matrix multiplication (without destination matrix) [IPP-Supported]
-      inline DynMatrix elementwise_div(const DynMatrix &m) const {
+      inline DynMatrix elementwise_div(const DynMatrix &m) const{
         DynMatrix dst(cols(),rows());
         return elementwise_div(m,dst);
       }
@@ -303,23 +303,23 @@ namespace icl{
 
 
       /// Essential matrix multiplication [IPP-Supported]
-      inline DynMatrix operator*(const DynMatrix &m) const {
+      inline DynMatrix operator*(const DynMatrix &m) const{
         DynMatrix d(m.cols(),rows());
         return mult(m,d);
       }
 
       /// inplace matrix multiplication applying this = this*m [IPP-Supported]
-      inline DynMatrix &operator*=(const DynMatrix &m) {
+      inline DynMatrix &operator*=(const DynMatrix &m){
         return *this=((*this)*m);
       }
 
       /// inplace matrix devision (calling this/m.inv()) [IPP-Supported]
-      inline DynMatrix operator/(const DynMatrix &m) const {
+      inline DynMatrix operator/(const DynMatrix &m) const{
         return this->operator*(m.inv());
       }
 
       /// inplace matrix devision (calling this/m.inv()) (inplace)
-      inline DynMatrix &operator/=(const DynMatrix &m) const {
+      inline DynMatrix &operator/=(const DynMatrix &m) const{
         return *this = this->operator*(m.inv());
       }
 
@@ -350,7 +350,7 @@ namespace icl{
       }
 
       /// Matrix addition
-      inline DynMatrix operator+(const DynMatrix &m) const {
+      inline DynMatrix operator+(const DynMatrix &m) const{
         if(cols() != m.cols() || rows() != m.rows()) throw IncompatibleMatrixDimensionException("A+B size(A) must be size(B)");
         DynMatrix d(cols(),rows());
         std::transform(begin(),end(),m.begin(),d.begin(),std::plus<T>());
@@ -358,7 +358,7 @@ namespace icl{
       }
 
       /// Matrix substraction
-      inline DynMatrix operator-(const DynMatrix &m) const {
+      inline DynMatrix operator-(const DynMatrix &m) const{
         if(cols() != m.cols() || rows() != m.rows()) throw IncompatibleMatrixDimensionException("A+B size(A) must be size(B)");
         DynMatrix d(cols(),rows());
         std::transform(begin(),end(),m.begin(),d.begin(),std::minus<T>());
@@ -366,14 +366,14 @@ namespace icl{
       }
 
       /// Matrix addition (inplace)
-      inline DynMatrix &operator+=(const DynMatrix &m) {
+      inline DynMatrix &operator+=(const DynMatrix &m){
         if(cols() != m.cols() || rows() != m.rows()) throw IncompatibleMatrixDimensionException("A+B size(A) must be size(B)");
         std::transform(begin(),end(),m.begin(),begin(),std::plus<T>());
         return *this;
       }
 
       /// Matrix substraction (inplace)
-      inline DynMatrix &operator-=(const DynMatrix &m) {
+      inline DynMatrix &operator-=(const DynMatrix &m){
         if(cols() != m.cols() || rows() != m.rows()) throw IncompatibleMatrixDimensionException("A+B size(A) must be size(B)");
         std::transform(begin(),end(),m.begin(),begin(),std::minus<T>());
         return *this;
@@ -396,13 +396,13 @@ namespace icl{
       }
 
       /// element access with index check
-      inline T &at(unsigned int col,unsigned int row) {
+      inline T &at(unsigned int col,unsigned int row){
         if(col>=cols() || row >= rows()) throw InvalidIndexException("row or col index too large");
         return m_data[col+cols()*row];
       }
 
       /// element access with index check (const)
-      inline const T &at(unsigned int col,unsigned int row) const {
+      inline const T &at(unsigned int col,unsigned int row) const{
         return const_cast<DynMatrix*>(this)->at(col,row);
       }
 
@@ -443,13 +443,13 @@ namespace icl{
       /** \endcond */
 
       /// returns the squared distance of the inner data vectors (linearly interpreted) (IPP accelerated)
-      inline T sqrDistanceTo(const DynMatrix &other) const {
+      inline T sqrDistanceTo(const DynMatrix &other) const{
         ICLASSERT_THROW(dim() == other.dim(), InvalidMatrixDimensionException("DynMatrix::sqrDistanceTo: dimension missmatch"));
         return std::inner_product(begin(),end(),other.begin(),T(0), std::plus<T>(), diff_power_two);
       }
 
       /// returns the distance of the inner data vectors (linearly interpreted) (IPP accelerated)
-      inline T distanceTo(const DynMatrix &other) const {
+      inline T distanceTo(const DynMatrix &other) const{
         ICLASSERT_THROW(dim() == other.dim(), InvalidMatrixDimensionException("DynMatrix::distanceTo: dimension missmatch"));
         return ::sqrt( distanceTo(other) );
       }
@@ -829,12 +829,10 @@ namespace icl{
       }
 
       /// applies QR-decomposition using stabilized Gram-Schmidt orthonormalization (only for icl32f and icl64f)
-      void decompose_QR(DynMatrix &Q, DynMatrix &R) const
-        ;
+      void decompose_QR(DynMatrix &Q, DynMatrix &R) const;
 
       /// applies RQ-decomposition (by exploiting implemnetation of QR-decomposition) (only for icl32f, and icl64f)
-      void decompose_RQ(DynMatrix &R, DynMatrix &Q) const
-        ;
+      void decompose_RQ(DynMatrix &R, DynMatrix &Q) const;
 
       /// applies LU-decomposition (without using partial pivoting) (only for icl32f and icl64f)
       /** Even though, implementation also works for non-sqared matrices, it's not recommended to
@@ -899,7 +897,7 @@ namespace icl{
 
 
       /// invert the matrix (only for icl32f and icl64f)
-      DynMatrix inv() const ;
+      DynMatrix inv() const;
 
       /// Extracts the matrix's eigenvalues and eigenvectors
       /** This function only works on squared symmetric matrices.
@@ -915,7 +913,7 @@ namespace icl{
           @param eigenvalues becomes a N-dimensional column vector which ith element is the eigenvalue that corresponds
                              to the ith column of eigenvectors
       */
-      void eigen(DynMatrix &eigenvectors, DynMatrix &eigenvalues) const ;
+      void eigen(DynMatrix &eigenvectors, DynMatrix &eigenvalues) const;
 
       /// Computes Singular Value Decomposition of a matrix - decomposes A into USV'
       /** Internaly, this function will always use double values. Other types are converted internally.
@@ -925,7 +923,7 @@ namespace icl{
           @param V is filled column-wise with the eigenvectors of A'A (in V, V is stored not V')
           @see icl::svd_dyn
       */
-      void svd(DynMatrix &U, DynMatrix &S, DynMatrix &V) const ;
+      void svd(DynMatrix &U, DynMatrix &S, DynMatrix &V) const;
 
       /// calculates the Moore-Penrose pseudo-inverse (only implemented for icl32f and icl64f)
       /** Internally, this functions can use either a QR-decomposition based approach, or it can use
@@ -952,8 +950,7 @@ namespace icl{
           return V * S * U.transp();
           </code>
       */
-      DynMatrix pinv(bool useSVD = false, T zeroThreshold = T(1E-16)) const
-        ;
+      DynMatrix pinv(bool useSVD = false, T zeroThreshold = T(1E-16)) const;
 
       /// calculates the Moore-Penrose pseudo-inverse (specialized for big matrices)
       /**
@@ -962,18 +959,16 @@ namespace icl{
       * @param zeroThreshold singular values below threshold are set to zero
       * @return pseudo inverse
       */
-      DynMatrix big_matrix_pinv(T zeroThreshold = T(1E-16)) const
-        ;
+      DynMatrix big_matrix_pinv(T zeroThreshold = T(1E-16)) const;
 
   #ifdef ICL_HAVE_MKL
       typedef void(*GESDD)(const char*, const int*, const int*, T*, const int*, T*, T*, const int*, T*, const int*, T*, const int*, int*, int*);
       typedef void(*CBLAS_GEMM)(CBLAS_ORDER,CBLAS_TRANSPOSE,CBLAS_TRANSPOSE,int,int,int,T,const T*,int,const T*,int,T,T*,int);
-      DynMatrix big_matrix_pinv(T zeroThreshold, GESDD gesdd, CBLAS_GEMM cblas_gemm) const
-        ;
+      DynMatrix big_matrix_pinv(T zeroThreshold, GESDD gesdd, CBLAS_GEMM cblas_gemm) const;
   #endif
 
       /// matrix determinant (only for icl32f and icl64f)
-      T det() const ;
+      T det() const;
 
       /// matrix transposed
       inline DynMatrix transp() const{
@@ -1007,7 +1002,7 @@ namespace icl{
           into a column vector matrix.
 
       */
-      inline void reshape(int newCols, int newRows) {
+      inline void reshape(int newCols, int newRows){
         if((cols() * rows()) != (newCols * newRows)){
           throw InvalidMatrixDimensionException("DynMatrix<T>::reshape: source dimension and destination dimension differs!");
         }
@@ -1026,7 +1021,7 @@ namespace icl{
       /** A.dot(B) is equivalent to A.transp() * B
           TODO: optimize implementation (current implementation _is_ A.transp() * B)
       */
-      DynMatrix<T> dot(const DynMatrix<T> &M) const {
+      DynMatrix<T> dot(const DynMatrix<T> &M) const{
         return this->transp() * M;
       }
 
@@ -1150,7 +1145,7 @@ namespace icl{
 #ifdef ICL_HAVE_IPP
     /** \cond */
     template<>
-    inline float DynMatrix<float>::sqrDistanceTo(const DynMatrix<float> &other) const {
+    inline float DynMatrix<float>::sqrDistanceTo(const DynMatrix<float> &other) const{
       ICLASSERT_THROW(dim() == other.dim(), InvalidMatrixDimensionException("DynMatrix::sqrDistanceTo: dimension missmatch"));
       float norm = 0 ;
       ippsNormDiff_L2_32f(begin(), other.begin(), dim(), &norm);
@@ -1158,7 +1153,7 @@ namespace icl{
     }
 
     template<>
-    inline double DynMatrix<double>::sqrDistanceTo(const DynMatrix<double> &other) const {
+    inline double DynMatrix<double>::sqrDistanceTo(const DynMatrix<double> &other) const{
       ICLASSERT_THROW(dim() == other.dim(), InvalidMatrixDimensionException("DynMatrix::sqrDistanceTo: dimension missmatch"));
       double norm = 0 ;
       ippsNormDiff_L2_64f(begin(), other.begin(), dim(), &norm);
@@ -1166,7 +1161,7 @@ namespace icl{
     }
 
     template<>
-    inline float DynMatrix<float>::distanceTo(const DynMatrix<float> &other) const {
+    inline float DynMatrix<float>::distanceTo(const DynMatrix<float> &other) const{
       ICLASSERT_THROW(dim() == other.dim(), InvalidMatrixDimensionException("DynMatrix::distanceTo: dimension missmatch"));
       float norm = 0 ;
       ippsNormDiff_L2_32f(begin(), other.begin(), dim(), &norm);
@@ -1174,7 +1169,7 @@ namespace icl{
     }
 
     template<>
-    inline double DynMatrix<double>::distanceTo(const DynMatrix<double> &other) const {
+    inline double DynMatrix<double>::distanceTo(const DynMatrix<double> &other) const{
       ICLASSERT_THROW(dim() == other.dim(), InvalidMatrixDimensionException("DynMatrix::distanceTo: dimension missmatch"));
       double norm = 0 ;
       ippsNormDiff_L2_64f(begin(), other.begin(), dim(), &norm);
@@ -1185,7 +1180,7 @@ namespace icl{
     template<>                                                          \
     inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::mult(            \
                                                             const DynMatrix<Ipp##IPPT> &m, DynMatrix<Ipp##IPPT> &dst) const \
-    {                       \
+    throw (IncompatibleMatrixDimensionException){                       \
       if(cols() != m.rows() ) throw IncompatibleMatrixDimensionException("A*B : cols(A) must be row(B)"); \
       dst.setBounds(m.cols(),rows());                                   \
       ippmMul_mm_##IPPT(data(),sizeof(Ipp##IPPT)*cols(),sizeof(Ipp##IPPT),cols(),rows(), \
@@ -1203,7 +1198,7 @@ namespace icl{
     template<>                                                          \
     inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::elementwise_div( \
                                                                        const DynMatrix<Ipp##IPPT> &m, DynMatrix<Ipp##IPPT> &dst) const \
-    {                       \
+    throw (IncompatibleMatrixDimensionException){                       \
       if((m.cols() != cols()) || (m.rows() != rows())){                 \
         throw IncompatibleMatrixDimensionException("A./B dimension mismatch"); \
       }                                                                 \

--- a/ICLMath/src/ICLMath/DynMatrix.h
+++ b/ICLMath/src/ICLMath/DynMatrix.h
@@ -272,7 +272,7 @@ namespace icl{
         if((m.cols() != cols()) || (m.rows() != rows())) throw IncompatibleMatrixDimensionException("A.*B dimension mismatch");
         dst.setBounds(cols(),rows());
         for(unsigned int i=0;i<dim();++i){
-  	dst[i] = m_data[i] * m[i];
+          dst[i] = m_data[i] * m[i];
         }
         return dst;
       }
@@ -288,7 +288,7 @@ namespace icl{
         if((m.cols() != cols()) || (m.rows() != rows())) throw IncompatibleMatrixDimensionException("A./B dimension mismatch");
         dst.setBounds(cols(),rows());
         for(int i=0;i<dim();++i){
-  	dst[i] = m_data[i] / m[i];
+          dst[i] = m_data[i] / m[i];
         }
         return dst;
       }
@@ -1178,9 +1178,7 @@ namespace icl{
 
 #define DYN_MATRIX_MULT_SPECIALIZE(IPPT)                                \
     template<>                                                          \
-    inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::mult(            \
-                                                            const DynMatrix<Ipp##IPPT> &m, DynMatrix<Ipp##IPPT> &dst) const \
-    throw (IncompatibleMatrixDimensionException){                       \
+    inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::mult(const DynMatrix<Ipp##IPPT> &m, DynMatrix<Ipp##IPPT> &dst) const{ \
       if(cols() != m.rows() ) throw IncompatibleMatrixDimensionException("A*B : cols(A) must be row(B)"); \
       dst.setBounds(m.cols(),rows());                                   \
       ippmMul_mm_##IPPT(data(),sizeof(Ipp##IPPT)*cols(),sizeof(Ipp##IPPT),cols(),rows(), \
@@ -1196,9 +1194,7 @@ namespace icl{
 
 #define DYN_MATRIX_ELEMENT_WISE_DIV_SPECIALIZE(IPPT)                    \
     template<>                                                          \
-    inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::elementwise_div( \
-                                                                       const DynMatrix<Ipp##IPPT> &m, DynMatrix<Ipp##IPPT> &dst) const \
-    throw (IncompatibleMatrixDimensionException){                       \
+    inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::elementwise_div(const DynMatrix<Ipp##IPPT> &m, DynMatrix<Ipp##IPPT> &dst) const{ \
       if((m.cols() != cols()) || (m.rows() != rows())){                 \
         throw IncompatibleMatrixDimensionException("A./B dimension mismatch"); \
       }                                                                 \
@@ -1219,8 +1215,7 @@ namespace icl{
 
 #define DYN_MATRIX_MULT_BY_CONSTANT(IPPT)                               \
     template<>                                                          \
-    inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::mult(            \
-                                                            Ipp##IPPT f, DynMatrix<Ipp##IPPT> &dst) const{ \
+    inline DynMatrix<Ipp##IPPT> &DynMatrix<Ipp##IPPT>::mult(Ipp##IPPT f, DynMatrix<Ipp##IPPT> &dst) const{ \
       dst.setBounds(cols(),rows());                                     \
       ippsMulC_##IPPT(data(),f, dst.data(),dim());                      \
       return dst;                                                       \

--- a/ICLMath/src/ICLMath/DynMatrixUtils.cpp
+++ b/ICLMath/src/ICLMath/DynMatrixUtils.cpp
@@ -286,19 +286,19 @@ namespace icl{
   #define INSTANTIATE_DYN_MATRIX_MATH_OP(op,func)                                                                                         \
     template<class T>                                                                                                                     \
     DynMatrix<T> &matrix_##op(const DynMatrix<T> &a, const DynMatrix<T> &b, DynMatrix<T> &dst)                                            \
-      throw (IncompatibleMatrixDimensionException){                                                                                       \
+    {                                                                                       \
       ERROR_LOG("not implemented for this type!");                                                                                        \
       return dst;                                                                                                                         \
     }                                                                                                                                     \
     template<> ICLMath_API DynMatrix<float> &matrix_##op(const DynMatrix<float> &a, const DynMatrix<float> &b, DynMatrix<float> &dst)     \
-      throw (IncompatibleMatrixDimensionException){                                                                                       \
+    {                                                                                       \
       CHECK_DIM(a,b,dst);                                                                                                                 \
       dst.setBounds(a.cols(), a.rows());                                                                                                  \
       ipps##func##_32f(b.begin(), a.begin(), dst.begin(), a.dim());                                                                       \
       return dst;                                                                                                                         \
     }                                                                                                                                     \
     template<> ICLMath_API DynMatrix<double> &matrix_##op(const DynMatrix<double> &a, const DynMatrix<double> &b, DynMatrix<double> &dst) \
-      throw (IncompatibleMatrixDimensionException){                                                                                       \
+    {                                                                                       \
       CHECK_DIM(a,b,dst);                                                                                                                 \
       dst.setBounds(a.cols(), a.rows());                                                                                                  \
       ipps##func##_64f(b.begin(), a.begin(), dst.begin(), a.dim());                                                                       \
@@ -486,16 +486,14 @@ namespace icl{
   #define INSTANTIATE_DYN_MATRIX_MATH_OP(op,func)                         \
     template<class T>                                                     \
     DynMatrix<T> &matrix_##op(const DynMatrix<T> &a, const DynMatrix<T> &b, DynMatrix<T> &dst) \
-      throw (IncompatibleMatrixDimensionException){                       \
+    {                       \
       CHECK_DIM(a,b,dst);                                                 \
       dst.setBounds(a.cols(),a.rows());                                   \
       std::transform(a.begin(),a.end(),b.begin(),dst.begin(),func);       \
       return dst;                                                         \
     }                                                                     \
-    template ICLMath_API DynMatrix<float> &matrix_##op(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&)     \
-       throw (IncompatibleMatrixDimensionException);                                                                \
-    template ICLMath_API DynMatrix<double> &matrix_##op(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&) \
-       throw (IncompatibleMatrixDimensionException);
+    template ICLMath_API DynMatrix<float> &matrix_##op(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&);    \
+    template ICLMath_API DynMatrix<double> &matrix_##op(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&);
 
     INSTANTIATE_DYN_MATRIX_MATH_OP(add,icl::math::addc<T>)
     INSTANTIATE_DYN_MATRIX_MATH_OP(sub,icl::math::subc<T>)

--- a/ICLMath/src/ICLMath/DynMatrixUtils.cpp
+++ b/ICLMath/src/ICLMath/DynMatrixUtils.cpp
@@ -286,19 +286,19 @@ namespace icl{
   #define INSTANTIATE_DYN_MATRIX_MATH_OP(op,func)                                                                                         \
     template<class T>                                                                                                                     \
     DynMatrix<T> &matrix_##op(const DynMatrix<T> &a, const DynMatrix<T> &b, DynMatrix<T> &dst)                                            \
-      {                                                                                       \
+      throw (IncompatibleMatrixDimensionException){                                                                                       \
       ERROR_LOG("not implemented for this type!");                                                                                        \
       return dst;                                                                                                                         \
     }                                                                                                                                     \
     template<> ICLMath_API DynMatrix<float> &matrix_##op(const DynMatrix<float> &a, const DynMatrix<float> &b, DynMatrix<float> &dst)     \
-      {                                                                                       \
+      throw (IncompatibleMatrixDimensionException){                                                                                       \
       CHECK_DIM(a,b,dst);                                                                                                                 \
       dst.setBounds(a.cols(), a.rows());                                                                                                  \
       ipps##func##_32f(b.begin(), a.begin(), dst.begin(), a.dim());                                                                       \
       return dst;                                                                                                                         \
     }                                                                                                                                     \
     template<> ICLMath_API DynMatrix<double> &matrix_##op(const DynMatrix<double> &a, const DynMatrix<double> &b, DynMatrix<double> &dst) \
-      {                                                                                       \
+      throw (IncompatibleMatrixDimensionException){                                                                                       \
       CHECK_DIM(a,b,dst);                                                                                                                 \
       dst.setBounds(a.cols(), a.rows());                                                                                                  \
       ipps##func##_64f(b.begin(), a.begin(), dst.begin(), a.dim());                                                                       \
@@ -486,16 +486,16 @@ namespace icl{
   #define INSTANTIATE_DYN_MATRIX_MATH_OP(op,func)                         \
     template<class T>                                                     \
     DynMatrix<T> &matrix_##op(const DynMatrix<T> &a, const DynMatrix<T> &b, DynMatrix<T> &dst) \
-      {                       \
+      throw (IncompatibleMatrixDimensionException){                       \
       CHECK_DIM(a,b,dst);                                                 \
       dst.setBounds(a.cols(),a.rows());                                   \
       std::transform(a.begin(),a.end(),b.begin(),dst.begin(),func);       \
       return dst;                                                         \
     }                                                                     \
     template ICLMath_API DynMatrix<float> &matrix_##op(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&)     \
-       ;                                                                \
+       throw (IncompatibleMatrixDimensionException);                                                                \
     template ICLMath_API DynMatrix<double> &matrix_##op(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&) \
-       ;
+       throw (IncompatibleMatrixDimensionException);
 
     INSTANTIATE_DYN_MATRIX_MATH_OP(add,icl::math::addc<T>)
     INSTANTIATE_DYN_MATRIX_MATH_OP(sub,icl::math::subc<T>)
@@ -677,8 +677,7 @@ namespace icl{
 
 
     template<class T>
-    DynMatrix<T> &matrix_muladd(const DynMatrix<T> &a,T alpha, const DynMatrix<T> &b, T beta, T gamma, DynMatrix<T> &dst)
-      {
+    DynMatrix<T> &matrix_muladd(const DynMatrix<T> &a,T alpha, const DynMatrix<T> &b, T beta, T gamma, DynMatrix<T> &dst){
       CHECK_DIM(a,b,dst);
       if(!alpha) return matrix_muladd(b,beta,gamma,dst);
       if(!beta) return matrix_muladd(a,alpha,gamma,dst);
@@ -686,10 +685,8 @@ namespace icl{
       std::transform(a.begin(),a.end(),b.begin(),dst.begin(),muladd_functor_2<T>(alpha,beta,gamma));
       return dst;
     }
-    template ICLMath_API DynMatrix<float> &matrix_muladd(const DynMatrix<float>&, float, const DynMatrix<float>&, float, float, DynMatrix<float>&)
-      ;
-    template ICLMath_API DynMatrix<double> &matrix_muladd(const DynMatrix<double>&, double, const DynMatrix<double>&, double, double, DynMatrix<double>&)
-      ;
+    template ICLMath_API DynMatrix<float> &matrix_muladd(const DynMatrix<float>&, float, const DynMatrix<float>&, float, float, DynMatrix<float>&);
+    template ICLMath_API DynMatrix<double> &matrix_muladd(const DynMatrix<double>&, double, const DynMatrix<double>&, double, double, DynMatrix<double>&);
 
 
     template<class T>
@@ -713,32 +710,26 @@ namespace icl{
     };
 
     template<class T>
-    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<T> &m)
-      {
+    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<T> &m){
       CHECK_DIM(mask,m,m);
       std::transform(mask.begin(),mask.end(),m.begin(),m.begin(),mask_functor<T>());
       return m;
     }
 
-    template ICLMath_API DynMatrix<float> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<float> &m)
-      ;
-    template ICLMath_API DynMatrix<double> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<double> &m)
-      ;
+    template ICLMath_API DynMatrix<float> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<float> &m);
+    template ICLMath_API DynMatrix<double> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<double> &m);
 
       /// applies masking operation (m(i,j) is set to 0 if mask(i,j) is 0)
     template<class T>
-    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<T> &m, DynMatrix<T> &dst)
-      {
+    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<T> &m, DynMatrix<T> &dst){
       CHECK_DIM(mask,m,dst);
       dst.setBounds(m.cols(),m.rows());
       std::transform(mask.begin(),mask.end(),m.begin(),dst.begin(),mask_functor<T>());
       return dst;
     }
 
-    template ICLMath_API DynMatrix<float> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<float> &m, DynMatrix<float> &dst)
-      ;
-    template ICLMath_API DynMatrix<double> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<double> &m, DynMatrix<double> &dst)
-      ;
+    template ICLMath_API DynMatrix<float> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<float> &m, DynMatrix<float> &dst);
+    template ICLMath_API DynMatrix<double> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<double> &m, DynMatrix<double> &dst);
 
 
 
@@ -750,18 +741,15 @@ namespace icl{
     };
 
     template<class T>
-    T matrix_distance(const DynMatrix<T> &m1, const DynMatrix<T> &m2, T norm)
-      {
+    T matrix_distance(const DynMatrix<T> &m1, const DynMatrix<T> &m2, T norm){
       CHECK_DIM(m1,m2,-1);
       ICLASSERT_RETURN_VAL(norm > 0,-1);
       T result = std::inner_product(m1.begin(),m1.end(),m2.begin(),T(0),std::plus<T>(),matrix_distance_op<T>(norm));
       return pow(result,1/norm);
     }
 
-    template ICLMath_API float matrix_distance(const DynMatrix<float> &m1, const DynMatrix<float> &m2, float)
-      ;
-    template ICLMath_API double matrix_distance(const DynMatrix<double> &, const DynMatrix<double> &, double)
-      ;
+    template ICLMath_API float matrix_distance(const DynMatrix<float> &m1, const DynMatrix<float> &m2, float);
+    template ICLMath_API double matrix_distance(const DynMatrix<double> &, const DynMatrix<double> &, double);
 
 
 
@@ -771,24 +759,20 @@ namespace icl{
     };
 
     template<class T>
-    T matrix_divergence(const DynMatrix<T> &m1, const DynMatrix<T> &m2)
-      {
+    T matrix_divergence(const DynMatrix<T> &m1, const DynMatrix<T> &m2){
       CHECK_DIM(m1,m2,-1);
       return std::inner_product(m1.begin(),m1.end(),m2.begin(),T(0),std::plus<T>(),matrix_divergence_op<T>());
     }
 
-    template ICLMath_API float matrix_divergence(const DynMatrix<float>&, const DynMatrix<float>&)
-      ;
-    template ICLMath_API double matrix_divergence(const DynMatrix<double>&, const DynMatrix<double>&)
-      ;
+    template ICLMath_API float matrix_divergence(const DynMatrix<float>&, const DynMatrix<float>&);
+    template ICLMath_API double matrix_divergence(const DynMatrix<double>&, const DynMatrix<double>&);
 
     /// matrix functions for transposed matrices ...
 
 
 
     template<class T>
-    DynMatrix<T> &matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-      {
+    DynMatrix<T> &matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef){
       switch(transpDef){
         case NONE_T: return src1.mult(src2,dst);
         case SRC1_T: return src1.transp().mult(src2,dst);
@@ -800,14 +784,12 @@ namespace icl{
     }
 
     template<class T>
-    DynMatrix<T> &big_matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-      {
+    DynMatrix<T> &big_matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef){
       return matrix_mult_t( src1, src2, dst, transpDef );
     }
 
     template<class T>
-    DynMatrix<T> &matrix_add_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-      {
+    DynMatrix<T> &matrix_add_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef){
       switch(transpDef){
         case NONE_T: return matrix_add(src1,src2,dst);
         case SRC1_T: return matrix_add(src1.transp(),src2,dst);
@@ -819,8 +801,7 @@ namespace icl{
     }
 
    template<class T>
-    DynMatrix<T> &matrix_sub_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-      {
+    DynMatrix<T> &matrix_sub_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef){
       switch(transpDef){
         case NONE_T: return matrix_sub(src1,src2,dst);
         case SRC1_T: return matrix_sub(src1.transp(),src2,dst);
@@ -857,8 +838,7 @@ namespace icl{
     }
 
 
-    template<> ICLMath_API DynMatrix<float> &matrix_add_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<float> &matrix_add_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM(src1,src2,dst);
@@ -880,8 +860,7 @@ namespace icl{
       }
       return dst;
     }
-    template<> ICLMath_API DynMatrix<double> &matrix_add_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<double> &matrix_add_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM(src1,src2,dst);
@@ -904,8 +883,7 @@ namespace icl{
       return dst;
     }
 
-    template<> ICLMath_API DynMatrix<float> &matrix_sub_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<float> &matrix_sub_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM(src1,src2,dst);
@@ -927,8 +905,7 @@ namespace icl{
       }
       return dst;
     }
-    template<> ICLMath_API DynMatrix<double> &matrix_sub_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<double> &matrix_sub_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM(src1,src2,dst);
@@ -952,8 +929,7 @@ namespace icl{
     }
 
 
-    template<> ICLMath_API DynMatrix<float> &matrix_mult_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<float> &matrix_mult_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM_CR(src1,src2,dst);
@@ -976,8 +952,7 @@ namespace icl{
       return dst;
     }
 
-    template<> ICLMath_API DynMatrix<double> &matrix_mult_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<double> &matrix_mult_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM_CR(src1,src2,dst);
@@ -1002,29 +977,22 @@ namespace icl{
 
   #else
 
-    template ICLMath_API DynMatrix<double> &matrix_mult_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int)
-      ;
-    template ICLMath_API DynMatrix<float> &matrix_mult_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int)
-      ;
+    template ICLMath_API DynMatrix<double> &matrix_mult_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int);
+    template ICLMath_API DynMatrix<float> &matrix_mult_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int);
 
-    template ICLMath_API DynMatrix<double> &matrix_add_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int)
-      ;
-    template ICLMath_API DynMatrix<float> &matrix_add_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int)
-      ;
+    template ICLMath_API DynMatrix<double> &matrix_add_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int);
+    template ICLMath_API DynMatrix<float> &matrix_add_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int);
 
 
-    template ICLMath_API DynMatrix<double> &matrix_sub_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int)
-      ;
-    template ICLMath_API DynMatrix<float> &matrix_sub_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int)
-      ;
+    template ICLMath_API DynMatrix<double> &matrix_sub_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int);
+    template ICLMath_API DynMatrix<float> &matrix_sub_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int);
 
   #endif // ICL_HAVE_IPP
 
 
     // optimized specialization only if MKL was found
   #ifdef ICL_HAVE_MKL
-    template<> ICLMath_API DynMatrix<float> &big_matrix_mult_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<float> &big_matrix_mult_t(const DynMatrix<float> &src1, const DynMatrix<float> &src2, DynMatrix<float> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM_CR(src1,src2,dst);
@@ -1054,8 +1022,7 @@ namespace icl{
       }
       return dst;
     }
-    template<> ICLMath_API DynMatrix<double> &big_matrix_mult_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef)
-      {
+    template<> ICLMath_API DynMatrix<double> &big_matrix_mult_t(const DynMatrix<double> &src1, const DynMatrix<double> &src2, DynMatrix<double> &dst, int transpDef){
       switch(transpDef){
         case NONE_T:
           CHECK_DIM_CR(src1,src2,dst);
@@ -1089,10 +1056,8 @@ namespace icl{
   #endif
 
 
-    template ICLMath_API DynMatrix<double> &big_matrix_mult_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int)
-      ;
-    template ICLMath_API DynMatrix<float> &big_matrix_mult_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int)
-      ;
+    template ICLMath_API DynMatrix<double> &big_matrix_mult_t(const DynMatrix<double>&, const DynMatrix<double>&, DynMatrix<double>&, int);
+    template ICLMath_API DynMatrix<float> &big_matrix_mult_t(const DynMatrix<float>&, const DynMatrix<float>&, DynMatrix<float>&, int);
 
 
   // undefine macros
@@ -1386,7 +1351,7 @@ namespace icl{
     }
   #else // use eigen
     template<class T>
-    void svd_eigen(const DynMatrix<T> &M, DynMatrix<T> &U, DynMatrix<T> &s, DynMatrix<T> &Vt) {
+    void svd_eigen(const DynMatrix<T> &M, DynMatrix<T> &U, DynMatrix<T> &s, DynMatrix<T> &Vt){
       typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> EigenMat;
 
       int sdim = iclMin(M.rows(),M.cols());
@@ -1414,12 +1379,12 @@ namespace icl{
 
 
     template<class T>
-    void svd_dyn(const DynMatrix<T> &A, DynMatrix<T> &U, DynMatrix<T> &s, DynMatrix<T> &V) {
+    void svd_dyn(const DynMatrix<T> &A, DynMatrix<T> &U, DynMatrix<T> &s, DynMatrix<T> &V){
       (void)A; (void)U; (void)s; (void)V;
     }
 
     template<>
-    ICLMath_API void svd_dyn(const DynMatrix<icl64f> &M, DynMatrix<icl64f> &U, DynMatrix<icl64f> &s, DynMatrix<icl64f> &Vt) {
+    ICLMath_API void svd_dyn(const DynMatrix<icl64f> &M, DynMatrix<icl64f> &U, DynMatrix<icl64f> &s, DynMatrix<icl64f> &Vt){
       unsigned int rows = M.rows(), cols = M.cols();
       U.setBounds(rows, rows);
       Vt.setBounds(cols, cols);
@@ -1479,7 +1444,7 @@ namespace icl{
     }
 
     template<>
-    ICLMath_API void svd_dyn(const DynMatrix<icl32f> &A, DynMatrix<icl32f> &U, DynMatrix<icl32f> &s, DynMatrix<icl32f> &V) {
+    ICLMath_API void svd_dyn(const DynMatrix<icl32f> &A, DynMatrix<icl32f> &U, DynMatrix<icl32f> &s, DynMatrix<icl32f> &V){
       U.setBounds(A.rows(), A.rows());
       V.setBounds(A.cols(), A.cols());
       s.setBounds(1, iclMin(A.rows(), A.cols()));

--- a/ICLMath/src/ICLMath/DynMatrixUtils.h
+++ b/ICLMath/src/ICLMath/DynMatrixUtils.h
@@ -240,38 +240,32 @@ namespace icl{
     /// element-wise atan2 function atan2(y,x) \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_arctan2(const DynMatrix<T> &my, const DynMatrix<T> &mx, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_arctan2(const DynMatrix<T> &my, const DynMatrix<T> &mx, DynMatrix<T> &dst);
 
     /// element-wise addition  [IPP-optimized] \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_add(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_add(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst);
 
     /// element-wise substraction  [IPP-optimized] \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_sub(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_sub(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst);
 
     /// element-wise multiplication  [IPP-optimized] \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_mul(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_mul(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst);
 
     /// element-wise division  [IPP-optimized] \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_div(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_div(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst);
 
     /// element-wise power \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_pow(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_pow(const DynMatrix<T> &m1, const DynMatrix<T> &m2, DynMatrix<T> &dst);
 
     /** @} */
     /** @{ @name matrix distance measurement  */
@@ -281,16 +275,14 @@ namespace icl{
         \f[ D = \left(\sum\limits_{i,j} (A_{ij}-B_{ij})^n\right)^{\frac{1}{n}} \f]
     */
     template<class T> ICLMath_IMP
-    T matrix_distance(const DynMatrix<T> &m1, const DynMatrix<T> &m2, T norm = 2)
-  	;
+    T matrix_distance(const DynMatrix<T> &m1, const DynMatrix<T> &m2, T norm = 2);
 
     /// computes generalized Kullback-Leibler-divergence between matrix vectors \ingroup LINALG
     /** For float and double only
         \f[ \mbox{div} = \sum\limits_{i,j} A_{ij} \cdot \log{\frac{A_{ij}}{B_{ij}}} - A_{ij} + B_{ij} \f]
     */
     template<class T> ICLMath_IMP
-    T matrix_divergence(const DynMatrix<T> &m1, const DynMatrix<T> &m2)
-  	;
+    T matrix_divergence(const DynMatrix<T> &m1, const DynMatrix<T> &m2);
 
 
     /** @} */
@@ -386,8 +378,7 @@ namespace icl{
     /// computes alpha*a + beta*b + gamma \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_muladd(const DynMatrix<T> &a, T alpha, const DynMatrix<T> &b, T beta, T gamma, DynMatrix<T> &dst)
-  	;
+    DynMatrix<T> &matrix_muladd(const DynMatrix<T> &a, T alpha, const DynMatrix<T> &b, T beta, T gamma, DynMatrix<T> &dst);
 
     /// computes alpha*a + gamma \ingroup LINALG
     /** For float and double only */
@@ -397,14 +388,12 @@ namespace icl{
     /// applies masking operation (m(i,j) is set to 0 if mask(i,j) is 0) (inplace) \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<T> &m)
-  	;
+    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, DynMatrix<T> &m);
 
     /// applies masking operation (m(i,j) is set to 0 if mask(i,j) is 0) \ingroup LINALG
     /** For float and double only */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<T> &m, DynMatrix<T> &dst)
-     	;
+    DynMatrix<T> &matrix_mask(const DynMatrix<unsigned char> &mask, const DynMatrix<T> &m, DynMatrix<T> &dst);
 
      /** @} */
 
@@ -432,8 +421,7 @@ namespace icl{
         @param transpDef or-ed list of transposedDef values e.g. (SRC1_T | SRC2_T) mean both matrices are transposed.
     */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-    ;
+    DynMatrix<T> &matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef);
 
     /// applies matrix mutliplication on optionally transposed matrices (specialized for big matrices) \ingroup LINALG
     /** sometimes, it might be more efficient to call matrix multiplication on imaginary transposed source matrices, to
@@ -448,18 +436,15 @@ namespace icl{
         @param transpDef or-ed list of transposedDef values e.g. (SRC1_T | SRC2_T) mean both matrices are transposed.
     */
     template<class T> ICLMath_IMP
-    DynMatrix<T> &big_matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-    ;
+    DynMatrix<T> &big_matrix_mult_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef);
 
     /// applies matrix addition on optionally transposed matrices \ingroup LINALG
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_add_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-    ;
+    DynMatrix<T> &matrix_add_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef);
 
     /// applies matrix substraction on optionally transposed matrices \ingroup LINALG
     template<class T> ICLMath_IMP
-    DynMatrix<T> &matrix_sub_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef)
-    ;
+    DynMatrix<T> &matrix_sub_t(const DynMatrix<T> &src1, const DynMatrix<T> &src2, DynMatrix<T> &dst, int transpDef);
 
     /** @} */
 
@@ -471,7 +456,7 @@ namespace icl{
         @param V is filled column-wise with the eigenvectors of A'A (in V, V is stored not V')
     */
     template<class T> ICLMath_IMP
-    void svd_dyn(const DynMatrix<T> &A, DynMatrix<T> &U, DynMatrix<T> &S, DynMatrix<T> &V) ;
+    void svd_dyn(const DynMatrix<T> &A, DynMatrix<T> &U, DynMatrix<T> &S, DynMatrix<T> &V);
 
 
   #if 0

--- a/ICLMath/src/ICLMath/DynVector.h
+++ b/ICLMath/src/ICLMath/DynVector.h
@@ -47,29 +47,29 @@ namespace icl{
       inline DynColVector():DynMatrix<T>(){};
 
       /// Creates a column vector with given dimension (and optional initialValue)
-      inline DynColVector(unsigned int dim,const T &initValue=0)  :
+      inline DynColVector(unsigned int dim,const T &initValue=0) :
         DynMatrix<T> (1,dim,initValue){}
 
       /// Create a column vector with given data
       /** Data can be wrapped deeply or shallowly. If the latter is true, given data pointer
           will not be released in the destructor, i.e. the data ownership is not passed to the
           DynColumnVector instance*/
-      inline DynColVector(unsigned int dim, T *data, bool deepCopy=true)  :
+      inline DynColVector(unsigned int dim, T *data, bool deepCopy=true) :
         DynMatrix<T>(1,dim,data,deepCopy){}
 
 
       /// Creates column vector with given data pointer and dimsion (const version: deepCopy only)
-      inline DynColVector(unsigned int dim, const T *data)  :
+      inline DynColVector(unsigned int dim, const T *data) :
         DynMatrix<T>(1,dim,data){}
 
       /// Default copy constructor (the source matrix column count must be 'one')
-      inline DynColVector(const DynMatrix<T> &other) :
+      inline DynColVector(const DynMatrix<T> &other):
         DynMatrix<T>(other){
         ICLASSERT_THROW(DynMatrix<T>::cols() == 1,
                         InvalidMatrixDimensionException("DynColVector(DynMatrix): source matrix has more than one column"));
       }
       /// assignment operator (the rvalue's column count must be one)
-      inline DynColVector<T> &operator=(const DynMatrix<T> &other) {
+      inline DynColVector<T> &operator=(const DynMatrix<T> &other){
         DynMatrix<T>::operator=(other);
         ICLASSERT_THROW(DynMatrix<T>::cols() == 1,
                         InvalidMatrixDimensionException("DynColVector = DynMatrix: source matrix has more than one column"));
@@ -77,12 +77,12 @@ namespace icl{
       }
       /// adapts the vector dimension
       /** overwrites setBounds from the parent matrix class to prevent the vector from being resized to matrix bounds */
-      inline void setBounds(unsigned int dim, bool holdContent=false, const T &initializer=0) {
+      inline void setBounds(unsigned int dim, bool holdContent=false, const T &initializer=0){
         DynMatrix<T>::setBounds(1,dim,holdContent,initializer);
       }
 
       /// adapts the vector dimension
-      inline void setDim(unsigned int dim, bool holdContent= false, const T &initializer=0) {
+      inline void setDim(unsigned int dim, bool holdContent= false, const T &initializer=0){
         setBounds(dim,holdContent,initializer);
       }
     };
@@ -93,29 +93,29 @@ namespace icl{
       inline DynRowVector():DynMatrix<T>(){}
 
       /// Creates a row vector with given dimension (and optional initialValue)
-      inline DynRowVector(unsigned int dim,const T &initValue=0)  :
+      inline DynRowVector(unsigned int dim,const T &initValue=0) :
         DynMatrix<T> (dim,1,initValue){}
 
       /// Create a row vector with given data
       /** Data can be wrapped deeply or shallowly. If the latter is true, given data pointer
           will not be released in the destructor, i.e. the data ownership is not passed to the
           DynColumnVector instance*/
-      inline DynRowVector(unsigned int dim, T *data, bool deepCopy=true)  :
+      inline DynRowVector(unsigned int dim, T *data, bool deepCopy=true) :
         DynMatrix<T>(dim,1,data,deepCopy){}
 
 
       /// Creates column vector with given data pointer and dimsion (const version: deepCopy only)
-      inline DynRowVector(unsigned int dim,const T *data)  :
+      inline DynRowVector(unsigned int dim,const T *data) :
         DynMatrix<T>(dim,1,data){}
 
       /// Default copy constructor (the source matrix row count must be 'one')
-      inline DynRowVector(const DynMatrix<T> &other) :
+      inline DynRowVector(const DynMatrix<T> &other):
         DynMatrix<T>(other){
         ICLASSERT_THROW(DynMatrix<T>::rows() == 1,
                         InvalidMatrixDimensionException("DynRowVector(DynMatrix): source matrix has more than one rows"));
       }
       /// assignment operator (the rvalue's column count must be one)
-      inline DynRowVector<T> &operator=(const DynMatrix<T> &other) {
+      inline DynRowVector<T> &operator=(const DynMatrix<T> &other){
         DynMatrix<T>::operator=(other);
         ICLASSERT_THROW(DynMatrix<T>::rows() == 1,
                         InvalidMatrixDimensionException("DynRowVector = DynMatrix: source matrix has more than one rows"));
@@ -124,12 +124,12 @@ namespace icl{
 
       /// adapts the vector dimension
       /** overwrites setBounds from the parent matrix class to prevent the vector from being resized to matrix bounds */
-      inline void setBounds(unsigned int dim, bool holdContent=false, const T &initializer=0) {
+      inline void setBounds(unsigned int dim, bool holdContent=false, const T &initializer=0){
         DynMatrix<T>::setBounds(dim,1,holdContent,initializer);
       }
 
       /// adapts the vector dimension
-      inline void setDim(unsigned int dim, bool holdContent= false, const T &initializer=0) {
+      inline void setDim(unsigned int dim, bool holdContent= false, const T &initializer=0){
         setBounds(dim,holdContent,initializer);
       }
 

--- a/ICLMath/src/ICLMath/FFTUtils.cpp
+++ b/ICLMath/src/ICLMath/FFTUtils.cpp
@@ -76,7 +76,7 @@ namespace icl{
 #undef ICL_INSTANTIATE_DEPTH
 
       template<typename T>
-      DynMatrix<T>&  fftshift(DynMatrix<T> &src,DynMatrix<T> &dst) {
+      DynMatrix<T>&  fftshift(DynMatrix<T> &src,DynMatrix<T> &dst){
 	if(src.cols() != dst.cols() || src.rows() != dst.rows())
           throw InvalidMatrixDimensionException("number of columns(rows) of sourcematrix must be equal to number of colums(rows) of destinationmatrix");
 	unsigned int cols = src.cols();
@@ -121,7 +121,7 @@ namespace icl{
 
       template<typename T>
       DynMatrix<T>&  ifftshift(DynMatrix<T> &src,
-                               DynMatrix<T> &dst) {
+                               DynMatrix<T> &dst){
 	if(src.cols() != dst.cols() || src.rows() != dst.rows())
           throw InvalidMatrixDimensionException("number of columns(rows) of sourcematrix must "
                                                 "be equal to number of colums(rows) "
@@ -856,7 +856,7 @@ namespace icl{
 #ifdef ICL_HAVE_IPP
       template<typename T>
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<T> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) {
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf){
 	FFT_DEBUG("using ipp fft");
 	IppiFFTSpec_R_32f *spec = 0;
 	//IppHintAlgorithm hint;
@@ -916,25 +916,25 @@ namespace icl{
       }
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<icl8u> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<icl16u> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<icl32u> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<icl16s> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<icl32s> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft(const DynMatrix<icl32f> &src,
-                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                           DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
 
       DynMatrix<icl32c >&  ipp_wrapper_function_result_fft_icl32fc(const DynMatrix<icl32c > &src,
-                                                                   DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) {
+                                                                   DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf){
 
 	IppiFFTSpec_C_32fc *spec = 0;
 	//IppHintAlgorithm hint;
@@ -1051,7 +1051,7 @@ namespace icl{
       template<typename T1,typename T2>
       DynMatrix<std::complex<T2> >&  mkl_wrapper_function_result_fft(
                                                                           const DynMatrix<T1> &src, DynMatrix<std::complex<T2> > &dst,
-                                                                          DynMatrix<std::complex<T2> > &buffer) {
+                                                                          DynMatrix<std::complex<T2> > &buffer){
 	FFT_DEBUG("using mkl fft2d");
 	unsigned int dimx = src.cols();
 	unsigned int dimy = src.rows();
@@ -1099,51 +1099,51 @@ namespace icl{
       }
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl8u> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl16u> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl32u> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl16s> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl32s> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl32f> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
 
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl8u> &src,
                                                                               DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl16u> &src,
-                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf) ;
+                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl32u> &src,
-                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf) ;
+                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl16s> &src,
-                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf) ;
+                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl32s> &src,
-                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf) ;
+                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl32f> &src,
-                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf) ;
+                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_fft(const DynMatrix<icl64f> &src,
-                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf) ;
+                                                                              DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buf);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_fft(const DynMatrix<icl64f> &src,
-                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                              DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
 
       template<typename T1,typename T2>
       void mkl_wrapper_function_result_fft_complex(DFTI_DESCRIPTOR_HANDLE &my_desc1_handle,T1 *src,
-                                                   std::complex<T2>*dst, std::complex<T2> *buffer, unsigned int dimx, unsigned int dimy) {
+                                                   std::complex<T2>*dst, std::complex<T2> *buffer, unsigned int dimx, unsigned int dimy){
 	FFT_DEBUG("using mkl fft2d_complex");
 
 	MKL_LONG status;
@@ -1179,11 +1179,11 @@ namespace icl{
                                                    icl32c *dst, icl32c *buffer,unsigned int dimx, unsigned int dimy);
       template
       void mkl_wrapper_function_result_fft_complex(DFTI_DESCRIPTOR_HANDLE &my_desc1_handle,_MKL_Complex16 *src,
-                                                   std::complex<icl64f> *dst, std::complex<icl64f> *buffer,unsigned int dimx, unsigned int dimy) ;
+                                                   std::complex<icl64f> *dst, std::complex<icl64f> *buffer,unsigned int dimx, unsigned int dimy);
 
 
       DynMatrix<icl32c >& mkl_wrapper_function_result_fft_icl32fc(const DynMatrix<icl32c > &src,
-                                                                                     DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) {
+                                                                                     DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer){
 	unsigned int dimx = src.cols();
 	unsigned int dimy = src.rows();
 	_MKL_Complex8 *srcbuf = new _MKL_Complex8[dimy*dimx];
@@ -1200,7 +1200,7 @@ namespace icl{
       }
 
       DynMatrix<std::complex<icl64f> >& mkl_wrapper_function_result_fft_icl64fc(const DynMatrix<std::complex<icl64f> > &src,
-                                                                                     DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) {
+                                                                                     DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer){
 	unsigned int dimx = src.cols();
 	unsigned int dimy = src.rows();
 	_MKL_Complex16 *srcbuf = new _MKL_Complex16[dimy*dimx];
@@ -1658,7 +1658,7 @@ namespace icl{
 #ifdef ICL_HAVE_IPP
       template<typename T>
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<T> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) {
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf){
 	FFT_DEBUG("using ipp ifft fc");
 	int dim = src.cols()*src.rows();
 	IppiFFTSpec_C_32fc *spec = 0;
@@ -1706,37 +1706,37 @@ namespace icl{
 
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl8u> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl16u> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32u> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl16s> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32s> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32f> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl64f> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32c > &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
       template
       DynMatrix<icl32c >&  ipp_wrapper_function_result_ifft_icl32fc(const DynMatrix<std::complex<icl64f> > &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buf);
 #endif
 
 #ifdef ICL_HAVE_MKL
       template<typename T1,typename T2>
       DynMatrix<std::complex<T2> >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<T1> &src,
-                                                                                   DynMatrix<std::complex<T2> > &dst,DynMatrix<std::complex<T2> > &buffer) {
+                                                                                   DynMatrix<std::complex<T2> > &dst,DynMatrix<std::complex<T2> > &buffer){
 	FFT_DEBUG("using mkl ifft2d fc");
 	int dim = src.cols()*src.rows();
 	unsigned int dimx = src.cols();
@@ -1794,35 +1794,35 @@ namespace icl{
       }
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl8u> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl16u> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32u> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl16s> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32s> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32f> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl64f> &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<icl32c > &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
       template
       DynMatrix<icl32c >&  mkl_wrapper_function_result_ifft_icl32fc(const DynMatrix<std::complex<icl64f> > &src,
-                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer) ;
+                                                                                       DynMatrix<icl32c > &dst,DynMatrix<icl32c > &buffer);
 
       template<typename T1,typename T2>
       DynMatrix<std::complex<T2> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<T1> &src,
-                                                                                   DynMatrix<std::complex<T2> > &dst,DynMatrix<std::complex<T2> > &buffer) {
+                                                                                   DynMatrix<std::complex<T2> > &dst,DynMatrix<std::complex<T2> > &buffer){
 	FFT_DEBUG("using mkl ifft2dfc");
 	int dim = src.cols()*src.rows();
 	unsigned int dimx = src.cols();
@@ -1880,31 +1880,31 @@ namespace icl{
       }
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl8u> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl16u> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl32u> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl16s> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl32s> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl32f> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl64f> &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<icl32c > &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
       template
       DynMatrix<std::complex<icl64f> >&  mkl_wrapper_function_result_ifft_icl64fc(const DynMatrix<std::complex<icl64f> > &src,
-                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer) ;
+                                                                                       DynMatrix<std::complex<icl64f> > &dst,DynMatrix<std::complex<icl64f> > &buffer);
 #endif
 
       template<typename T1, typename T2>

--- a/ICLMath/src/ICLMath/FFTUtils.h
+++ b/ICLMath/src/ICLMath/FFTUtils.h
@@ -189,7 +189,7 @@ namespace icl{
      @return destinationmatrix
    */
   template<typename T> ICLMath_IMP
-  DynMatrix<T>& fftshift(DynMatrix<T> &src, DynMatrix<T> &dst) ;
+  DynMatrix<T>& fftshift(DynMatrix<T> &src, DynMatrix<T> &dst);
 
   ///invers function to fftshift.
   /**Shifts the center of the matrix into the upper left corner .
@@ -198,7 +198,7 @@ namespace icl{
      @return destinationmatrix
    */
   template<typename T> ICLMath_IMP
-  DynMatrix<T>& ifftshift(DynMatrix<T> &src, DynMatrix<T> &dst) ;
+  DynMatrix<T>& ifftshift(DynMatrix<T> &src, DynMatrix<T> &dst);
 
   ///computes the powerspectrum
   /**Computes and returns the powerspectrum of a matrix with complex values.

--- a/ICLMath/src/ICLMath/FixedMatrix.h
+++ b/ICLMath/src/ICLMath/FixedMatrix.h
@@ -299,12 +299,12 @@ namespace icl{
           Only allowed form square matrices B
           @param m denominator for division expression
       */
-      FixedMatrix operator/(const FixedMatrix &m) const {
+      FixedMatrix operator/(const FixedMatrix &m) const{
         return this->operator*(m.inv());
       }
 
       /// Matrix devision (inplace)
-      FixedMatrix &operator/=(const FixedMatrix &m) {
+      FixedMatrix &operator/=(const FixedMatrix &m){
                  return *this = this->operator*(m.inv());
       }
 
@@ -407,13 +407,13 @@ namespace icl{
       }
 
       /// Element access index save (with exception if index is invalid)
-      T &at(unsigned int col,unsigned int row) {
+      T &at(unsigned int col,unsigned int row){
         if(col>=cols() || row >= rows()) throw InvalidIndexException("row or col index too large");
         return begin()[col+cols()*row];
       }
 
       /// Element access index save (with exception if index is invalid) (const)
-      const T &at(unsigned int col,unsigned int row) const {
+      const T &at(unsigned int col,unsigned int row) const{
         return const_cast<FixedMatrix*>(this)->at(col,row);
       }
 
@@ -712,7 +712,7 @@ namespace icl{
           <b>Note:</b> Inv will not compute a pseudo inverse matrix. Include iclFixedMatrixUtils.h
           instead and use the non-member template function pinv() instead for pseudo-inverse calculation
       */
-      FixedMatrix inv() const {
+      FixedMatrix inv() const{
         return FixedMatrix(dyn().inv().data());
       }
 
@@ -720,7 +720,7 @@ namespace icl{
       /** This function internally uses an instance of DynMatrix<T>
           Additionally implemented (in closed form) for float and double for 2x2 3x3 and 4x4 matrices
       */
-      T det() const {
+      T det() const{
         return dyn().det();
       }
 
@@ -868,7 +868,7 @@ namespace icl{
 
 
       /// returns a vector of the diagonal elements (only for squared matrices)
-      FixedMatrix<T,1,ROWS> diag() const {
+      FixedMatrix<T,1,ROWS> diag() const{
         if(ROWS != COLS) throw InvalidMatrixDimensionException("trace is only possible for sqaure matrices");
         FixedMatrix<T,1,ROWS> t;
         for(unsigned int i=0;i<ROWS;++i){
@@ -1106,14 +1106,14 @@ namespace icl{
   #define SPECIALISED_MATRIX_INV_AND_DET(D,T) \
     template<>                                                            \
     inline FixedMatrix<T,D,D> FixedMatrix<T,D,D>::inv() const             \
-    {      \
+    throw (InvalidMatrixDimensionException,SingularMatrixException){      \
       FixedMatrix<T,D,D> r;                                               \
       icl_util_get_fixed_##D##x##D##_matrix_inv<T>(begin(),r.begin());    \
       return r;                                                           \
     }                                                                     \
     template<>                                                            \
     inline T FixedMatrix<T,D,D>::det() const                              \
-    {                               \
+    throw(InvalidMatrixDimensionException){                               \
       return icl_util_get_fixed_##D##x##D##_matrix_det<T>(begin());       \
     }
 

--- a/ICLMath/src/ICLMath/FixedMatrix.h
+++ b/ICLMath/src/ICLMath/FixedMatrix.h
@@ -1105,15 +1105,13 @@ namespace icl{
 
   #define SPECIALISED_MATRIX_INV_AND_DET(D,T) \
     template<>                                                            \
-    inline FixedMatrix<T,D,D> FixedMatrix<T,D,D>::inv() const             \
-    throw (InvalidMatrixDimensionException,SingularMatrixException){      \
+    inline FixedMatrix<T,D,D> FixedMatrix<T,D,D>::inv() const {           \
       FixedMatrix<T,D,D> r;                                               \
       icl_util_get_fixed_##D##x##D##_matrix_inv<T>(begin(),r.begin());    \
       return r;                                                           \
     }                                                                     \
     template<>                                                            \
-    inline T FixedMatrix<T,D,D>::det() const                              \
-    throw(InvalidMatrixDimensionException){                               \
+    inline T FixedMatrix<T,D,D>::det() const {                            \
       return icl_util_get_fixed_##D##x##D##_matrix_det<T>(begin());       \
     }
 

--- a/ICLMath/src/ICLMath/LeastSquareModelFitting.h
+++ b/ICLMath/src/ICLMath/LeastSquareModelFitting.h
@@ -184,7 +184,7 @@ namespace icl{
       /** Internally we use a workaround when the matrix inversion fails due to stability
           problems. If the standard matrix inversion fails, a SVD-based inversion is
           used */
-      Model fit(const std::vector<DataPoint> &points) {
+      Model fit(const std::vector<DataPoint> &points){
         const int M = m_modelDim;
         const int N = (int)points.size();
 

--- a/ICLMath/src/ICLMath/Octree.h
+++ b/ICLMath/src/ICLMath/Octree.h
@@ -292,7 +292,7 @@ namespace icl{
       protected:
 
       /// internal utility method that is used to find an approximated nearest neighbour
-      const Pt &nn_approx_internal(const Pt &p, double &currMinDist, const Pt *&currNN) const {
+      const Pt &nn_approx_internal(const Pt &p, double &currMinDist, const Pt *&currNN) const{
         // 1st find cell, that continas p
         const Node *n = root;
         while(n->children){
@@ -341,7 +341,7 @@ namespace icl{
           can easily be 5 times as fast as the real nearest neighbor search.
           The result quality depends on the number of contained points, and
           on the QuadTree's template parameters */
-      Pt nn_approx(const Pt &p) const {
+      Pt nn_approx(const Pt &p) const{
         double currMinDist = sqrt(utils::Range<Scalar>::limits().maxVal-1);
         const Pt *currNN  = 0;
         nn_approx_internal(scale_up(p),currMinDist,currNN);
@@ -367,7 +367,7 @@ namespace icl{
           If no neighbour could be found, an exception is thown. This should
           actually only happen when nn is called on an empty QuadTree
       */
-      Pt nn(const Pt &pIn) const {
+      Pt nn(const Pt &pIn) const{
         const Pt p = scale_up(pIn);
         std::vector<const Node*> stack;
         stack.reserve(128);

--- a/ICLMath/src/ICLMath/QuadTree.h
+++ b/ICLMath/src/ICLMath/QuadTree.h
@@ -439,7 +439,7 @@ namespace icl{
       protected:
 
       /// internal utility method that is used to find an approximated nearest neighbour
-      const Pt &nn_approx_internal(const Pt &p, double &currMinDist, const Pt *&currNN) const {
+      const Pt &nn_approx_internal(const Pt &p, double &currMinDist, const Pt *&currNN) const{
         // 1st find cell, that continas p
         const Node *n = root;
         while(n->children){
@@ -481,7 +481,7 @@ namespace icl{
           can easily be 5 times as fast as the real nearest neighbor search.
           The result quality depends on the number of contained points, and
           on the QuadTree's template parameters */
-      Pt nn_approx(const Pt &p) const {
+      Pt nn_approx(const Pt &p) const{
         double currMinDist = sqrt(utils::Range<Scalar>::limits().maxVal-1);
         const Pt *currNN  = 0;
         nn_approx_internal(p*SF /*Pt(SF*p[0],SF*p[1])*/,currMinDist,currNN);
@@ -507,7 +507,7 @@ namespace icl{
           If no neighbour could be found, an exception is thown. This should
           actually only happen when nn is called on an empty QuadTree
       */
-      Pt nn(const Pt &pIn) const {
+      Pt nn(const Pt &pIn) const{
         const Pt p = pIn*SF;//p(SF*pIn[0],SF*pIn[1]);
         std::vector<const Node*> stack;
         stack.reserve(128);
@@ -542,13 +542,13 @@ namespace icl{
       }
 
       /// convenience wrapper for the Point32f type
-      const utils::Point32f nn(const utils::Point32f &p) const {
+      const utils::Point32f nn(const utils::Point32f &p) const{
         Pt n = nn(Pt(p.x,p.y));
         return utils::Point32f(n[0],n[1]);
       }
 
       /// convenience wrapper for the Point32f type
-      const utils::Point nn(const utils::Point &p) const {
+      const utils::Point nn(const utils::Point &p) const{
         Pt n = nn(Pt(p.x,p.y));
         return utils::Point(n[0],n[1]);
       }

--- a/ICLMath/src/ICLMath/StraightLine2D.cpp
+++ b/ICLMath/src/ICLMath/StraightLine2D.cpp
@@ -79,7 +79,7 @@ namespace icl{
       return ((v*fac)-p).length();
     }
 
-    StraightLine2D::Pos StraightLine2D::intersect(const StraightLine2D &other) const {
+    StraightLine2D::Pos StraightLine2D::intersect(const StraightLine2D &other) const{
       float A1,B1,C1,A2,B2,C2;
       {
         Pos a=o;

--- a/ICLPhysics/demos/physics-paper/SceneMultiCamCapturer.cpp
+++ b/ICLPhysics/demos/physics-paper/SceneMultiCamCapturer.cpp
@@ -76,12 +76,12 @@ namespace icl{
   }
 
   SceneMultiCamCapturer::SceneMultiCamCapturer(Scene &scene, int num, int* camIndices,
-                                               const std::string &progArgName) {
+                                               const std::string &progArgName){
     init(scene,num, camIndices,progArgName);
   }
 
   void SceneMultiCamCapturer::init(Scene &scene, int num, int* camIndices,
-                                   const std::string &progArgName) {
+                                   const std::string &progArgName){
     this->scene = &scene;
     this->camIndices.assign(camIndices,camIndices+num);
 

--- a/ICLPhysics/demos/physics-paper/SceneMultiCamCapturer.h
+++ b/ICLPhysics/demos/physics-paper/SceneMultiCamCapturer.h
@@ -47,10 +47,10 @@ namespace icl{
     SceneMultiCamCapturer(geom::Scene &scene, const std::vector<geom::Camera> &cams=std::vector<geom::Camera>());
 
     SceneMultiCamCapturer(geom::Scene &scene, int num, int* camIndices,
-                          const std::string &progArgName="-o") ;
+                          const std::string &progArgName="-o");
 
     void init(geom::Scene &scene, int num, int* camIndices,
-              const std::string &progArgName="-o") ;
+              const std::string &progArgName="-o");
 
     void capture();
   };

--- a/ICLPhysics/src/ICLPhysics/SceneMultiCamCapturer.cpp
+++ b/ICLPhysics/src/ICLPhysics/SceneMultiCamCapturer.cpp
@@ -77,12 +77,12 @@ namespace icl{
     }
 
     SceneMultiCamCapturer::SceneMultiCamCapturer(Scene &scene, int num, int* camIndices,
-                                                 const std::string &progArgName) {
+                                                 const std::string &progArgName){
       init(scene,num, camIndices,progArgName);
     }
 
     void SceneMultiCamCapturer::init(Scene &scene, int num, int* camIndices,
-                                     const std::string &progArgName) {
+                                     const std::string &progArgName){
       this->scene = &scene;
       this->camIndices.assign(camIndices,camIndices+num);
 

--- a/ICLPhysics/src/ICLPhysics/SceneMultiCamCapturer.h
+++ b/ICLPhysics/src/ICLPhysics/SceneMultiCamCapturer.h
@@ -49,10 +49,10 @@ namespace icl{
       SceneMultiCamCapturer(geom::Scene &scene, const std::vector<geom::Camera> &cams=std::vector<geom::Camera>());
 
       SceneMultiCamCapturer(geom::Scene &scene, int num, int* camIndices,
-                            const std::string &progArgName="-o") ;
+                            const std::string &progArgName="-o");
 
       void init(geom::Scene &scene, int num, int* camIndices,
-                const std::string &progArgName="-o") ;
+                const std::string &progArgName="-o");
 
       void capture();
     };

--- a/ICLPhysics/src/ICLPhysics/SoftObject.cpp
+++ b/ICLPhysics/src/ICLPhysics/SoftObject.cpp
@@ -183,7 +183,7 @@ namespace physics{
 
   }
 
-  SoftObject::SoftObject(const std::string &objFileName, PhysicsWorld *world) {
+  SoftObject::SoftObject(const std::string &objFileName, PhysicsWorld *world){
     File file(objFileName,File::readText);
     if(!file.exists()) throw ICLException("Error in SceneObject(objFilename): unable to open file " + objFileName);
 

--- a/ICLPhysics/src/ICLPhysics/SoftObject.h
+++ b/ICLPhysics/src/ICLPhysics/SoftObject.h
@@ -60,7 +60,7 @@ namespace physics{
 
     public:
     /// constructor that uses an obj-file to create a softbody
-    SoftObject(const std::string &objFileName, PhysicsWorld *world) ;
+    SoftObject(const std::string &objFileName, PhysicsWorld *world);
     /// returns internal physical object as softBody
     /** Soft bodys are simple soft-body physical objects */
     virtual btSoftBody *getSoftBody();

--- a/ICLQt/src/ICLQt/AdjustGridMouseHandler.cpp
+++ b/ICLQt/src/ICLQt/AdjustGridMouseHandler.cpp
@@ -323,7 +323,7 @@ namespace icl{
       return m_data->bounds;
     }
 
-    void AdjustGridMouseHandler::setGrid(size_t idx, const utils::Point psIn[4]) {
+    void AdjustGridMouseHandler::setGrid(size_t idx, const utils::Point psIn[4]){
       if(idx >= m_data->grids.size()){
         throw ICLException("AdjustGridMouseHandler: setGrid invalid index");
       }
@@ -358,7 +358,7 @@ namespace icl{
       }
     }
 
-    std::vector<Point> AdjustGridMouseHandler::getGrid(size_t idx) const {
+    std::vector<Point> AdjustGridMouseHandler::getGrid(size_t idx) const{
       Mutex::Locker lock(this);
       if(!m_data) {
         throw ICLException("AdjustGridMouseHandler::getGrid() was called before it was initialized!");

--- a/ICLQt/src/ICLQt/AdjustGridMouseHandler.h
+++ b/ICLQt/src/ICLQt/AdjustGridMouseHandler.h
@@ -87,13 +87,13 @@ namespace icl{
                                              const std::vector<utils::Point32f> &ps) const;
 
       /// returns the current quadrangle
-      std::vector<utils::Point> getGrid(size_t idx) const ;
+      std::vector<utils::Point> getGrid(size_t idx) const;
 
       /// sets the current quadrangle
       /** If the given quadrangle is not completely covered by the
           image rect, or the convexOnly flag is activated and the
           given quadrangle is not convex, an exception is thrown*/
-      void setGrid(size_t idx, const utils::Point ps[4]) ;
+      void setGrid(size_t idx, const utils::Point ps[4]);
 
       /// returns whether this mousehandler has been initialized yet
       inline bool isNull() const { return !m_data; }

--- a/ICLQt/src/ICLQt/Application.cpp
+++ b/ICLQt/src/ICLQt/Application.cpp
@@ -136,8 +136,7 @@ namespace icl{
                                  const std::string &paInitString,
                                  callback init, callback run,
                                  callback run2, callback run3,
-                                 callback run4, callback run5)
-    {
+                                 callback run4, callback run5){
     if(s_app) throw SecondSingeltonException("only one instance is allowed!");
     if(paInitString != ""){
       pa_init(n,ppc,paInitString);

--- a/ICLQt/src/ICLQt/DataStore.cpp
+++ b/ICLQt/src/ICLQt/DataStore.cpp
@@ -752,7 +752,7 @@ namespace icl{
     }
 
     void DataStore::Data::assign(void *src, const std::string &srcType,
-                                 void *dst, const std::string &dstType) {
+                                 void *dst, const std::string &dstType){
       AssignMap *am = create_singelton_assign_map();
       AssignMap::iterator it1 = am->find(srcType);
       if(it1 == am->end()){
@@ -769,7 +769,7 @@ namespace icl{
     }
 
 
-    DataStore::Data DataStore::operator[](const std::string &key) {
+    DataStore::Data DataStore::operator[](const std::string &key){
       DataMap::iterator it = m_oDataMapPtr->find(key);
       if(it == m_oDataMapPtr->end()) throw KeyNotFoundException(key);
       return Data(&it->second);

--- a/ICLQt/src/ICLQt/DataStore.h
+++ b/ICLQt/src/ICLQt/DataStore.h
@@ -70,7 +70,7 @@ namespace icl{
 
         /// This is the mighty and magic conversion function
         ICLQt_API static void assign(void *src, const std::string &srcType, void *dst,
-                           const std::string &dstType) ;
+                           const std::string &dstType);
 
         public:
 
@@ -90,7 +90,7 @@ namespace icl{
         /// Trys to assign an instance of T to this Data-Element
         /** This will only work, if the data types are assignable */
         template<class T>
-        inline void operator=(const T &t) {
+        inline void operator=(const T &t){
           assign(const_cast<void*>(reinterpret_cast<const void*>(&t)),
                  get_type_name<T>(),data->data,data->type);
         }
@@ -99,7 +99,7 @@ namespace icl{
         /** this will only work, if the data element is convertable to the
             desired type. Otherwise an exception is thrown*/
         template<class T>
-        inline T as() const {
+        inline T as() const{
           T t;
           assign(data->data,data->type,&t,get_type_name<T>());
           return t;
@@ -107,7 +107,7 @@ namespace icl{
 
         /// implicit conversion into l-value type (little dangerous)
         template<class T>
-        operator T() const {
+        operator T() const{
           return as<T>();
         }
 
@@ -116,12 +116,12 @@ namespace icl{
 
 
         /** Currently supported for Data-types ImageHandle, DrawHandle, FPSHandle and PlotHandle */
-        void render() {
+        void render(){
           *this = Event("render");
         }
 
         /// links DrawWidget3D and GLCallback
-        void link(void *data) {
+        void link(void *data){
           *this = Event("link", data);
         }
 
@@ -200,7 +200,7 @@ namespace icl{
           x["sl"] = Range32s(3,9);   // sets slider's Range ...
           \endcode
       */
-      Data operator[](const std::string &key) ;
+      Data operator[](const std::string &key);
 
 
       /// convenience function that allows collecting data from different source entries

--- a/ICLQt/src/ICLQt/DefineQuadrangleMouseHandler.cpp
+++ b/ICLQt/src/ICLQt/DefineQuadrangleMouseHandler.cpp
@@ -91,7 +91,7 @@ namespace icl{
       m_data->handleSize = 8;
     }
 
-    void DefineQuadrangleMouseHandler::setQuadrangle(const utils::Point ps[4]) {
+    void DefineQuadrangleMouseHandler::setQuadrangle(const utils::Point ps[4]){
       Rect r(Point::null,Size(m_data->bounds.width+1,m_data->bounds.height+1));
 
       for(int i=0;i<4;++i){

--- a/ICLQt/src/ICLQt/DefineQuadrangleMouseHandler.h
+++ b/ICLQt/src/ICLQt/DefineQuadrangleMouseHandler.h
@@ -81,7 +81,7 @@ namespace icl{
       /** If the given quadrangle is not completely covered by the
           image rect, or the convexOnly flag is activated and the
           given quadrangle is not convex, an exception is thrown*/
-      void setQuadrangle(const utils::Point ps[4]) ;
+      void setQuadrangle(const utils::Point ps[4]);
 
       /// returns whether this mousehandler has been initialized yet
       inline bool isNull() const { return !m_data; }

--- a/ICLQt/src/ICLQt/GLFragmentShader.cpp
+++ b/ICLQt/src/ICLQt/GLFragmentShader.cpp
@@ -155,7 +155,7 @@ namespace icl{
 
     GLFragmentShader::GLFragmentShader(const std::string &vertexProgram,
                                        const std::string &fragmentProgram,
-                                       bool createOnFirstActivate) :
+                                       bool createOnFirstActivate):
       m_data(new Data){
 
         if(!vertexProgram.length() && !fragmentProgram.length()){

--- a/ICLQt/src/ICLQt/GLFragmentShader.h
+++ b/ICLQt/src/ICLQt/GLFragmentShader.h
@@ -51,7 +51,7 @@ namespace icl{
       public:
       GLFragmentShader(const std::string &vertexProgram,
                        const std::string &fragmentProgram,
-                       bool createOnFirstActivate=true) ;
+                       bool createOnFirstActivate=true);
       ~GLFragmentShader();
 
       void setUniform(const std::string var, const float &val);

--- a/ICLQt/src/ICLQt/GUIComponents.h
+++ b/ICLQt/src/ICLQt/GUIComponents.h
@@ -294,7 +294,7 @@ namespace icl{
       Prop(const std::string &configurableID):GUIComponent("prop",configurableID){}
 
       /// create configurable component from given configurable (pointer)
-      Prop(const utils::Configurable *cfg)  : GUIComponent("prop","@pointer@:"+utils::Any::ptr(cfg)){
+      Prop(const utils::Configurable *cfg) : GUIComponent("prop","@pointer@:"+utils::Any::ptr(cfg)){
         ICLASSERT_THROW(cfg, utils::ICLException("GUIComponent Prop(NULL-Pointer) cannot be created!"));
       }
 

--- a/ICLQt/src/ICLQt/GUISyntaxErrorException.h
+++ b/ICLQt/src/ICLQt/GUISyntaxErrorException.h
@@ -40,9 +40,9 @@ namespace icl{
     /// Internally used and caught exception class for the GUI API \ingroup UNCOMMON
     class GUISyntaxErrorException : public utils::ICLException {
       public:
-      GUISyntaxErrorException(const std::string &guidef, const std::string &problem) throw():
+      GUISyntaxErrorException(const std::string &guidef, const std::string &problem) noexcept:
       utils::ICLException(std::string("Syntax Error while parsing:\n\"")+guidef+"\"\n("+problem+")\n") {}
-      virtual ~GUISyntaxErrorException() throw() {}
+      virtual ~GUISyntaxErrorException() noexcept {}
     };
   } // namespace qt
 }

--- a/ICLQt/src/ICLQt/QtVideoGrabber.cpp
+++ b/ICLQt/src/ICLQt/QtVideoGrabber.cpp
@@ -35,7 +35,7 @@
 
 namespace icl{
   namespace qt{
-    QtVideoGrabber::QtVideoGrabber(const std::string &filename)  {
+    QtVideoGrabber::QtVideoGrabber(const std::string &filename) {
 
       if(!File(filename).exists()){
         throw FileNotFoundException(filename);

--- a/ICLQt/src/ICLQt/QtVideoGrabber.h
+++ b/ICLQt/src/ICLQt/QtVideoGrabber.h
@@ -45,7 +45,7 @@ namespace icl{
       public:
 
         /// Create video grabber with given video-file name
-        QtVideoGrabber(const std::string &filename) ;
+        QtVideoGrabber(const std::string &filename);
 
         /// Destructor
         ~QtVideoGrabber();

--- a/ICLQt/src/ICLQt/Quick.cpp
+++ b/ICLQt/src/ICLQt/Quick.cpp
@@ -284,7 +284,7 @@ namespace icl{
     }
 
     std::string openFileDialog(const std::string &filter,const std::string &caption,
-                               const std::string &initialDirectory, void *parentWidget) {
+                               const std::string &initialDirectory, void *parentWidget){
       static std::string lastDirectory = ".";
       IOContext c = { filter, caption, (initialDirectory=="_____last"?lastDirectory:initialDirectory), parentWidget, std::string(), false };
       ICLApp::instance()->executeInGUIThread<IOContext&>(do_open, c,true);
@@ -304,7 +304,7 @@ namespace icl{
           }
           */
     std::string saveFileDialog(const std::string &filter,const std::string &caption,
-                               const std::string &initialDirectory,void *parentWidget) {
+                               const std::string &initialDirectory,void *parentWidget){
       static std::string lastDirectory = ".";
       IOContext c = { filter, caption, (initialDirectory=="_____last"?lastDirectory:initialDirectory), parentWidget, std::string(), false };
       ICLApp::instance()->executeInGUIThread<IOContext&>(do_save, c,true);
@@ -326,7 +326,7 @@ namespace icl{
     std::string textInputDialog(const std::string &caption, const std::string &message,
                                 const std::string &initialText, void *parentWidget,
                                 core::ImgBase *visImage,
-                                std::vector<std::string> completionOptions) {
+                                std::vector<std::string> completionOptions){
       TextIOContext c = { caption, message, initialText, parentWidget, std::string(), false, visImage, completionOptions };
 
       ICLApp::instance()->executeInGUIThread<TextIOContext&>(do_gettext, c, true);

--- a/ICLQt/src/ICLQt/Quick.h
+++ b/ICLQt/src/ICLQt/Quick.h
@@ -75,14 +75,14 @@ namespace icl{
     ICLQt_API std::string openFileDialog(const std::string &filter = "",
                                const std::string &caption="open file",
                                const std::string &initialDirectory="_____last",
-                               void *parentWidget=0) ;
+                               void *parentWidget=0);
 
     /// uses Qt to spawn a save-file dialog with given filter
     /** throws an exception if cancel was pressed. The function is thread-safe and can savely be called from a working thread */
     ICLQt_API std::string saveFileDialog(const std::string &filter = "",
                                const std::string &caption="save file",
                                const std::string &initialDirectory="_____last",
-                               void *parentWidget=0) ;
+                               void *parentWidget=0);
 
     /// uses Qt to spawn a text input dialog
     /** throws an exception if cancel was pressed. The function is thread-safe and can savely be
@@ -93,7 +93,7 @@ namespace icl{
                                 const std::string &initialText="",
                                 void *parentWidget=0,
                                 core::ImgBase *visImage=0,
-                                std::vector<std::string> completionOptions=std::vector<std::string>()) ;
+                                std::vector<std::string> completionOptions=std::vector<std::string>());
 
 
     /// executes the given command as a child process and returns it output

--- a/ICLUtils/src/ICLUtils/CLBuffer.cpp
+++ b/ICLUtils/src/ICLUtils/CLBuffer.cpp
@@ -46,8 +46,7 @@ namespace icl {
       cl::Buffer buffer;
       cl::CommandQueue cmdQueue;
 
-      static cl_mem_flags stringToMemFlags(const string &accessMode)
-         {
+      static cl_mem_flags stringToMemFlags(const string &accessMode) {
         switch(accessMode.length()){
           case 1:
             if(accessMode[0] == 'w') return CL_MEM_WRITE_ONLY;
@@ -72,8 +71,7 @@ namespace icl {
       }
 
       Impl(cl::Context &context, cl::CommandQueue &cmdQueue,
-           const string &accessMode, size_t size,const void *src = 0)
-         {
+           const string &accessMode, size_t size,const void *src = 0):cmdQueue(cmdQueue) {
         cl_mem_flags memFlags = stringToMemFlags(accessMode);
         if (src) {
           memFlags = memFlags | CL_MEM_COPY_HOST_PTR;
@@ -87,8 +85,7 @@ namespace icl {
 
       }
 
-      void copy(cl::Buffer &dst, int len, int src_offset = 0, int dst_offset = 0)
-         {
+      void copy(cl::Buffer &dst, int len, int src_offset = 0, int dst_offset = 0) {
         try {
           cmdQueue.enqueueCopyBuffer(buffer, dst, src_offset, dst_offset, len);
         } catch (cl::Error& error) {
@@ -96,8 +93,7 @@ namespace icl {
         }
       }
 
-      void read(void *dst, int len, int offset = 0, bool block = true)
-         {
+      void read(void *dst, int len, int offset = 0, bool block = true) {
         cl_bool blocking;
         if (block)
           blocking = CL_TRUE;
@@ -110,8 +106,7 @@ namespace icl {
         }
       }
 
-      void write(const void *src, int len, int offset = 0, bool block = true)
-         {
+      void write(const void *src, int len, int offset = 0, bool block = true) {
         cl_bool blocking;
         if (block)
           blocking = CL_TRUE;
@@ -128,7 +123,6 @@ namespace icl {
 
     CLBuffer::CLBuffer(cl::Context &context, cl::CommandQueue &cmdQueue,
                        const string &accessMode, size_t size,const void *src)
-	  
 		: CLMemory(CLMemory::Buffer) {
 		impl = new Impl(context, cmdQueue, accessMode, size, src);
 		setDimensions(size,1,1);
@@ -137,7 +131,6 @@ namespace icl {
 
 	CLBuffer::CLBuffer(cl::Context &context, cl::CommandQueue &cmdQueue,
 					   const string &accessMode, size_t length, size_t byteDepth,const void *src)
-	  
 		: CLMemory(CLMemory::Buffer) {
 		impl = new Impl(context, cmdQueue, accessMode, byteDepth*length, src);
 		setDimensions(length,1,1);
@@ -165,20 +158,17 @@ namespace icl {
       delete impl;
     }
 
-    void CLBuffer::copy(CLBuffer &dst, int len, int src_offset, int dst_offset)
-       {
+    void CLBuffer::copy(CLBuffer &dst, int len, int src_offset, int dst_offset) {
       impl->copy(dst.getBuffer(), len, src_offset, dst_offset);
 
     }
 
-    void CLBuffer::read(void *dst, int len, int offset, bool block)
-       {
+    void CLBuffer::read(void *dst, int len, int offset, bool block) {
       impl->read(dst, len, offset, block);
 
     }
 
-    void CLBuffer::write(const void *src, int len, int offset, bool block)
-       {
+    void CLBuffer::write(const void *src, int len, int offset, bool block) {
       impl->write(src, len, offset, block);
     }
 

--- a/ICLUtils/src/ICLUtils/CLBuffer.h
+++ b/ICLUtils/src/ICLUtils/CLBuffer.h
@@ -55,10 +55,10 @@ namespace icl {
 
       /// private constructor (buffer can only be created by CLProgram instances)
       CLBuffer(cl::Context& context, cl::CommandQueue &cmdQueue,
-               const string &accessMode, size_t size, const void *src=NULL) ;
+               const string &accessMode, size_t size, const void *src=NULL);
 
 	  CLBuffer(cl::Context& context, cl::CommandQueue &cmdQueue, const string &accessMode,
-			   size_t length, size_t byte_depth, const void *src=NULL) ;
+			   size_t length, size_t byte_depth, const void *src=NULL);
 
       /// provides access to the underlying cl-buffer
       cl::Buffer &getBuffer();
@@ -82,13 +82,13 @@ namespace icl {
       ~CLBuffer();
 
       /// copies the content of this buffer into the given buffer
-      void copy(CLBuffer &dst, int len, int src_offset = 0, int dst_offset = 0) ;
+      void copy(CLBuffer &dst, int len, int src_offset = 0, int dst_offset = 0);
 
       /// reads buffer from graphics memory into given destination pointer
-      void read(void *dst, int len, int offset = 0, bool block = true) ;
+      void read(void *dst, int len, int offset = 0, bool block = true);
 
       /// writes source data into the graphics memory
-      void write(const void *src, int len, int offset = 0, bool block = true) ;
+      void write(const void *src, int len, int offset = 0, bool block = true);
 
       /// checks whether buffer is null
       bool isNull() const {

--- a/ICLUtils/src/ICLUtils/CLDeviceContext.cpp
+++ b/ICLUtils/src/ICLUtils/CLDeviceContext.cpp
@@ -57,7 +57,7 @@ namespace icl {
 
 			Impl() : m_device_type_str("") {}
 
-                  void init(std::string const &device_type_str)  {
+                  void init(std::string const &device_type_str) {
                     m_device_type_str = device_type_str;
                     cl_device_type device_type = stringToDeviceType(m_device_type_str);
                     try {
@@ -90,7 +90,7 @@ namespace icl {
 			}
 
 			void selectFirstDevice(const cl_device_type deviceType,
-                                               const std::vector<cl::Platform>& platformList)  {
+                                               const std::vector<cl::Platform>& platformList) {
 			  for (unsigned int i = 0; i < platformList.size(); i++) { //check all platforms
                             std::vector<cl::Device> deviceList;
                             try {
@@ -174,7 +174,7 @@ namespace icl {
 
 			}
 
-			static cl_device_type stringToDeviceType(string deviceType)  {
+			static cl_device_type stringToDeviceType(string deviceType) {
 			  if (deviceType.compare("gpu") == 0) {
 				return CL_DEVICE_TYPE_GPU;
 			  } else if (deviceType.compare("cpu") == 0) {
@@ -218,21 +218,21 @@ namespace icl {
 			}
 
 			CLBuffer createBuffer(const string &accessMode, size_t size,
-								  const void *src = 0)  {
+								  const void *src = 0) {
 				return CLBuffer(context, cmdQueue, accessMode, size, src);
 			}
 
 			CLBuffer createBuffer(const string &accessMode, size_t length, size_t byteDepth,
-								  const void *src = 0)  {
+								  const void *src = 0) {
 				return CLBuffer(context, cmdQueue, accessMode, length, byteDepth, src);
 			}
 
-			CLImage2D createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src=0) {
+			CLImage2D createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src=0){
 				return CLImage2D(context, cmdQueue, accessMode, width, height, depth, num_channel, src, supported_channel_orders);
 			}
 
 			CLBuffer *createBufferHeap(const string &accessMode, size_t length, size_t byteDepth,
-								  const void *src = 0)  {
+								  const void *src = 0) {
 				CLBuffer *res = 0;
 				try {
 					res = new CLBuffer(context, cmdQueue, accessMode, length, byteDepth, src);
@@ -244,7 +244,7 @@ namespace icl {
 				return res;
 			}
 
-			CLImage2D *createImage2DHeap(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src=0) {
+			CLImage2D *createImage2DHeap(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src=0){
 				CLImage2D *res = 0;
 				try {
 					res = new CLImage2D(context, cmdQueue, accessMode, width, height, depth, num_channel, src, supported_channel_orders);
@@ -260,12 +260,12 @@ namespace icl {
 
 		// /////////////////////////////////////////////////////////////////////////////////////////
 
-		CLDeviceContext::CLDeviceContext() 
+		CLDeviceContext::CLDeviceContext()
 			: impl(0) {
 			impl = new Impl();
 		}
 
-		CLDeviceContext::CLDeviceContext(std::string const &device) 
+		CLDeviceContext::CLDeviceContext(std::string const &device)
 			: impl(0) {
 			impl = new Impl();
 			try {
@@ -297,27 +297,27 @@ namespace icl {
 			return *this;
 		}
 
-		CLBuffer CLDeviceContext::createBuffer(const string &accessMode, size_t size, const void *src)  {
+		CLBuffer CLDeviceContext::createBuffer(const string &accessMode, size_t size, const void *src) {
 		  return impl->createBuffer(accessMode, size, src);
 		}
 
-		CLBuffer CLDeviceContext::createBuffer(const string &accessMode, size_t length, size_t byteDepth, const void *src)  {
+		CLBuffer CLDeviceContext::createBuffer(const string &accessMode, size_t length, size_t byteDepth, const void *src) {
 			return impl->createBuffer(accessMode,length,byteDepth,src);
 		}
 
-		CLImage2D CLDeviceContext::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, const void *src) {
+		CLImage2D CLDeviceContext::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, const void *src){
 			return impl->createImage2D(accessMode, width, height, depth, 1, src);
 		}
 
-		CLImage2D CLDeviceContext::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src) {
+		CLImage2D CLDeviceContext::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src){
 			return impl->createImage2D(accessMode, width, height, depth, num_channel, src);
 		}
 
-		CLBuffer *CLDeviceContext::createBufferHeap(const string &accessMode, size_t length, size_t byteDepth, const void *src)  {
+		CLBuffer *CLDeviceContext::createBufferHeap(const string &accessMode, size_t length, size_t byteDepth, const void *src) {
 		  return impl->createBufferHeap(accessMode, length, byteDepth, src);
 		}
 
-		CLImage2D *CLDeviceContext::createImage2DHeap(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src) {
+		CLImage2D *CLDeviceContext::createImage2DHeap(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src){
 			return impl->createImage2DHeap(accessMode, width, height, depth, num_channel, src);
 		}
 

--- a/ICLUtils/src/ICLUtils/CLDeviceContext.h
+++ b/ICLUtils/src/ICLUtils/CLDeviceContext.h
@@ -81,12 +81,12 @@ namespace icl {
 			/**
 			 * @brief CLDeviceContext Creates a dummy CLDeviceContext
 			 */
-			CLDeviceContext() ;
+			CLDeviceContext();
 			/**
 			 * @brief CLDeviceContext Creates a CLDeviceContext on the given device type
 			 * @param device type of device as string. Current supported device types: "gpu","cpu".
 			 */
-			CLDeviceContext(std::string const &device) ;
+			CLDeviceContext(std::string const &device);
 			/**
 			 * @brief CLDeviceContext Creates a shallow copy of the given CLDeviceContext
 			 * @param other another CLDeviceContext to copy from
@@ -116,7 +116,7 @@ namespace icl {
 			 *
 			 * Throws a CLBufferException in case of allocation problems.\n
 			 */
-			CLBuffer createBuffer(const string &accessMode, size_t size, const void *src=0) ;
+			CLBuffer createBuffer(const string &accessMode, size_t size, const void *src=0);
 
 			/**
 			 * @brief createBuffer createBuffer creates a buffer object for memory exchange with graphics card memory
@@ -127,7 +127,7 @@ namespace icl {
 			 * @param src Optional source pointer. If not NULL the content of this pointer will automatically be uploaded to the device.
 			 * @return
 			 */
-			CLBuffer createBuffer(const string &accessMode, size_t length, size_t byteDepth, const void *src = 0) ;
+			CLBuffer createBuffer(const string &accessMode, size_t length, size_t byteDepth, const void *src = 0);
 
 			/**
 			 * @brief createImage2D Creates a image2D object for memory exchange with graphics card memory
@@ -147,7 +147,7 @@ namespace icl {
 			 * In this case, the number of channels are assumed to be equal to one.\n
 			 * Throws a CLBufferException in case of allocation problems.\n
 			 */
-			CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, const void *src=0) ;
+			CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, const void *src=0);
 
 			/**
 			 * @brief createImage2D
@@ -166,7 +166,7 @@ namespace icl {
 			 *
 			 * Throws a CLBufferException in case of allocation problems.\n
 			 */
-			CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, int num_channel, const void *src=0) ;
+			CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, int num_channel, const void *src=0);
 
 			/**
 			 * @brief getDeviceTypeString Returns the device type as string
@@ -204,7 +204,7 @@ namespace icl {
 			 *
 			 * Throws a CLBufferException in case of allocation problems.\n
 			 */
-			CLBuffer *createBufferHeap(const string &accessMode, size_t length, size_t byteDepth, const void *src=0) ;
+			CLBuffer *createBufferHeap(const string &accessMode, size_t length, size_t byteDepth, const void *src=0);
 
 			/**
 			 * @brief createImage2DHeap Creates a image2D object pointer for memory exchange with graphics card memory. The pointer has to be handles by the user
@@ -224,7 +224,7 @@ namespace icl {
 			 *
 			 * Throws a CLBufferException in case of allocation problems.\n
 			 */
-			CLImage2D *createImage2DHeap(const string &accessMode, const size_t width, const size_t height, int depth, int num_channel, const void *src=0) ;
+			CLImage2D *createImage2DHeap(const string &accessMode, const size_t width, const size_t height, int depth, int num_channel, const void *src=0);
 		};
 
 	}

--- a/ICLUtils/src/ICLUtils/CLException.h
+++ b/ICLUtils/src/ICLUtils/CLException.h
@@ -47,28 +47,28 @@ namespace icl {
 				sstr << message << " clErrorCode " << errorCode << endl;
 				return sstr.str();
 			}
-			CLException(const std::string &msg) throw() : ICLException(msg) {}
+			CLException(const std::string &msg) noexcept : ICLException(msg) {}
 		};
 		/// Class for an OpenCL Exception during initialization
     class CLInitException: public CLException {
 		public:
-			CLInitException(const std::string &msg) throw() : CLException(msg) {}
+			CLInitException(const std::string &msg) noexcept : CLException(msg) {}
 		};
 		/// Class for an OpenCL Exception during kernel compiling
     class CLBuildException: public CLException {
 		public:
-			CLBuildException(const std::string &msg) throw() : CLException(msg) {}
+			CLBuildException(const std::string &msg) noexcept : CLException(msg) {}
 		};
 		/// Class for an OpenCL Exception associated with buffers
     class CLBufferException: public CLException {
 		public:
-			CLBufferException(const std::string &msg) throw() : CLException(msg) {}
+			CLBufferException(const std::string &msg) noexcept : CLException(msg) {}
 		};
 
 		/// Class for an OpenCL Exception associated with kernels
     class CLKernelException: public CLException {
 		public:
-			CLKernelException(const std::string &msg) throw() : CLException(msg) {}
+			CLKernelException(const std::string &msg) noexcept : CLException(msg) {}
 		};
 
 	}

--- a/ICLUtils/src/ICLUtils/CLImage2D.cpp
+++ b/ICLUtils/src/ICLUtils/CLImage2D.cpp
@@ -51,8 +51,7 @@ namespace icl {
 			cl::CommandQueue cmdQueue;
 			std::map< uint32_t,set<uint32_t> > supported_channel_orders;
 
-            static cl_mem_flags stringToMemFlags(const string &accessMode)
-             {
+            static cl_mem_flags stringToMemFlags(const string &accessMode) {
                 switch(accessMode.length()) {
                     case 1:
                     if(accessMode[0] == 'w') return CL_MEM_WRITE_ONLY;
@@ -105,7 +104,7 @@ namespace icl {
             Impl(cl::Context &context, cl::CommandQueue &cmdQueue,
                     const string &accessMode, const size_t width, const size_t height,
 					int depth, int num_channel, const void *src = 0, const std::map<uint32_t, std::set<uint32_t> >
-					&supported_formats = std::map< uint32_t,std::set<uint32_t> >()) 
+					&supported_formats = std::map< uint32_t,std::set<uint32_t> >())
 				:cmdQueue(cmdQueue), supported_channel_orders(supported_formats) {
 
                 cl_mem_flags memFlags = stringToMemFlags(accessMode);
@@ -161,8 +160,7 @@ namespace icl {
                 clRegion[2] = 1;
             }
 
-            void read(void *dst, const utils::Rect &region=utils::Rect::null, bool block = true)
-             {
+            void read(void *dst, const utils::Rect &region=utils::Rect::null, bool block = true) {
                 cl_bool blocking;
                 if (block)
                 blocking = CL_TRUE;
@@ -179,8 +177,7 @@ namespace icl {
             }
 
             void write(void *src, const utils::Rect &region=utils::Rect::null,
-                    bool block = true)
-             {
+                    bool block = true) {
                 cl_bool blocking;
                 if (block)
                 blocking = CL_TRUE;
@@ -213,7 +210,6 @@ namespace icl {
 				const string &accessMode, const size_t width, const size_t height,
 				int depth, int num_channel, const void *src,
 				const std::map<uint32_t, std::set<uint32_t> > &supported_formats)
-		
 			: CLMemory(CLMemory::Image2D) {
             impl = new Impl(context, cmdQueue, accessMode, width, height,
 					depth, num_channel, src, supported_formats);
@@ -246,15 +242,13 @@ namespace icl {
             delete impl;
         }
 
-        void CLImage2D::read(void *dst, const utils::Rect &region, bool block)
-         {
+        void CLImage2D::read(void *dst, const utils::Rect &region, bool block) {
             impl->read(dst, region, block);
 
         }
 
         void CLImage2D::write(const void *src, const utils::Rect &region,
-                bool block)
-         {
+                bool block) {
             impl->write((void *)src, region, block);
         }
 

--- a/ICLUtils/src/ICLUtils/CLImage2D.h
+++ b/ICLUtils/src/ICLUtils/CLImage2D.h
@@ -62,7 +62,7 @@ namespace icl {
 			CLImage2D(cl::Context& context, cl::CommandQueue &cmdQueue,
 					const string &accessMode, const size_t width, const size_t height,
 					int depth, int num_channel, const void *src=NULL, std::map< uint32_t, std::set<uint32_t> > const
-					  &supported_formats = std::map< uint32_t, std::set<uint32_t> >()) ;
+					  &supported_formats = std::map< uint32_t, std::set<uint32_t> >());
 
             /// provides access to the underlying cl-Image2D object
             cl::Image2D getImage2D();
@@ -89,13 +89,13 @@ namespace icl {
             /// reads image from graphics memory into given destination pointer
             /** region defines the accessed image area. When no region is provided
              *  the complete image is addressed(initial width, height and (0, 0) as origin */
-            void read(void *dst, const utils::Rect &region=utils::Rect::null,  bool block = true) ;
+            void read(void *dst, const utils::Rect &region=utils::Rect::null,  bool block = true);
 
             /// writes source data into the graphics memory
             /** region defines the accessed image area. When no region is provided
              *  the complete image is addressed(initial width, height and (0, 0) as origin */
             void write(const void *src,const utils::Rect &region=utils::Rect::null,
-                    bool block = true) ;
+                    bool block = true);
 
             /// checks whether image is null
             bool isNull() const {

--- a/ICLUtils/src/ICLUtils/CLKernel.cpp
+++ b/ICLUtils/src/ICLUtils/CLKernel.cpp
@@ -45,8 +45,7 @@ namespace icl {
 	  Impl(Impl& other):cmdQueue(other.cmdQueue){
         kernel = other.kernel;
       }
-      Impl(cl::Program& program, cl::CommandQueue& cmdQueue, const string &id)
-         {
+      Impl(cl::Program& program, cl::CommandQueue& cmdQueue, const string &id):cmdQueue(cmdQueue) {
         try {
           kernel = cl::Kernel(program, id.c_str());
         } catch (cl::Error& error) {
@@ -54,7 +53,7 @@ namespace icl {
         }
       }
 
-	  void finish()  {
+	  void finish() {
 		  try {
 			  cmdQueue.finish();
 		  } catch (cl::Error& error) {
@@ -63,7 +62,7 @@ namespace icl {
 	  }
 
       void apply(int gloW, int gloH = 0, int gloC = 0,
-                 int locW = 0, int locH = 0, int locC = 0) {
+                 int locW = 0, int locH = 0, int locC = 0){
         cl::NDRange globRange;
         if (gloH > 0)
           {
@@ -108,8 +107,7 @@ namespace icl {
       }
 
       template<class T>
-      void setArg(const unsigned idx, const T &value)
-         {
+      void setArg(const unsigned idx, const T &value) {
         try
           {
             kernel.setArg(idx, value);
@@ -118,8 +116,7 @@ namespace icl {
         }
       }
 
-      void setArg(const unsigned idx, const CLKernel::LocalMemory &value)
-         {
+      void setArg(const unsigned idx, const CLKernel::LocalMemory &value) {
         try
           {
             kernel.setArg(idx, value.size, NULL);
@@ -130,16 +127,16 @@ namespace icl {
 
     };
     CLKernel::CLKernel(const string &id, cl::Program & program,
-                       cl::CommandQueue& cmdQueue)  {
+                       cl::CommandQueue& cmdQueue) {
       impl = new Impl(program, cmdQueue, id);
 
     }
     void CLKernel::apply(int gloW, int gloH, int gloC,
-                         int locW, int locH, int locC) {
+                         int locW, int locH, int locC){
       impl->apply(gloW, gloH, gloC, locW, locH, locC);
     }
 
-	void CLKernel::finish()  {
+	void CLKernel::finish() {
 		impl->finish();
 	}
 
@@ -160,51 +157,51 @@ namespace icl {
       return *this;
     }
 
-    void CLKernel::setArg(const unsigned idx, const unsigned int &value) {
+    void CLKernel::setArg(const unsigned idx, const unsigned int &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const int &value) {
+    void CLKernel::setArg(const unsigned idx, const int &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const short &value) {
+    void CLKernel::setArg(const unsigned idx, const short &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const long &value) {
+    void CLKernel::setArg(const unsigned idx, const long &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const unsigned long &value) {
+    void CLKernel::setArg(const unsigned idx, const unsigned long &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const float &value) {
+    void CLKernel::setArg(const unsigned idx, const float &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const double &value) {
+    void CLKernel::setArg(const unsigned idx, const double &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const char &value) {
+    void CLKernel::setArg(const unsigned idx, const char &value){
       impl->setArg(idx, value);
     }
-    void CLKernel::setArg(const unsigned idx, const unsigned char &value) {
+    void CLKernel::setArg(const unsigned idx, const unsigned char &value){
       impl->setArg(idx, value);
     }
 
-    void CLKernel::setArg(const unsigned idx, const CLBuffer &value) {
+    void CLKernel::setArg(const unsigned idx, const CLBuffer &value){
       impl->setArg(idx, value.getBuffer());
     }
 
-    void CLKernel::setArg(const unsigned idx, const CLImage2D &value) {
+    void CLKernel::setArg(const unsigned idx, const CLImage2D &value){
       impl->setArg(idx, value.getImage2D());
     }
 
-    void CLKernel::setArg(const unsigned idx, const LocalMemory &value) {
+    void CLKernel::setArg(const unsigned idx, const LocalMemory &value){
       impl->setArg(idx, value);
     }
 
-    void CLKernel::setArg(const unsigned idx, const FixedArray<float,4> &value) {
+    void CLKernel::setArg(const unsigned idx, const FixedArray<float,4> &value){
       impl->setArg(idx, value);
     }
 
-    void CLKernel::setArg(const unsigned idx, const FixedArray<float,3> &value) {
+    void CLKernel::setArg(const unsigned idx, const FixedArray<float,3> &value){
       impl->setArg(idx, value);
     }
   }

--- a/ICLUtils/src/ICLUtils/CLKernel.h
+++ b/ICLUtils/src/ICLUtils/CLKernel.h
@@ -75,7 +75,7 @@ namespace icl {
 
       /// private constructor (CLKernel instances can only be created by CLPrograms)
       CLKernel(const string &id, cl::Program & program,
-               cl::CommandQueue& cmdQueue) ;
+               cl::CommandQueue& cmdQueue);
 
       public:
 
@@ -102,80 +102,80 @@ namespace icl {
       /// executes kernel with given global and local coordinates
       /** gloW can be accessed in the kernel code by get_global_id(0), and so on */
       void apply(int gloW, int gloH = 0, int gloC = 0,
-                 int locW = 0, int locH = 0, int locC = 0) ;
+                 int locW = 0, int locH = 0, int locC = 0);
 
 	  /// calls the finish-fkt. of opencl to wait until the command queue is done
-	  void finish() ;
+	  void finish();
 
       /// for tight integration with the CLProgram class
       friend class CLProgram;
 	  friend class CLDeviceContext;
 
       /// Overloaded Kernel argument setter for unsigned int values
-      void setArg(const unsigned idx, const unsigned int &value) ;
+      void setArg(const unsigned idx, const unsigned int &value);
 
       /// Overloaded Kernel argument setter for int values
-      void setArg(const unsigned idx, const int &value) ;
+      void setArg(const unsigned idx, const int &value);
 
       /// Overloaded Kernel argument setter for short values
-      void setArg(const unsigned idx, const short &value) ;
+      void setArg(const unsigned idx, const short &value);
 
       /// Overloaded Kernel argument setter for long values
-      void setArg(const unsigned idx, const long &value) ;
+      void setArg(const unsigned idx, const long &value);
 
       /// Overloaded Kernel argument setter for unsigned long values
-      void setArg(const unsigned idx, const unsigned long &value) ;
+      void setArg(const unsigned idx, const unsigned long &value);
 
       /// Overloaded Kernel argument setter for float values
-      void setArg(const unsigned idx, const float &value) ;
+      void setArg(const unsigned idx, const float &value);
 
       /// Overloaded Kernel argument setter for double values
-      void setArg(const unsigned idx, const double &value) ;
+      void setArg(const unsigned idx, const double &value);
 
       /// Overloaded Kernel argument setter for char values
-      void setArg(const unsigned idx, const char &value) ;
+      void setArg(const unsigned idx, const char &value);
 
       /// Overloaded Kernel argument setter for unsigned char values
-      void setArg(const unsigned idx, const unsigned char &value) ;
+      void setArg(const unsigned idx, const unsigned char &value);
 
       /// Overloaded Kernel argument setter for 4D vectors
-      void setArg(const unsigned idx, const FixedArray<float,4> &value) ;
+      void setArg(const unsigned idx, const FixedArray<float,4> &value);
 
       /// Overloaded Kernel argument setter for 3D vectors
-      void setArg(const unsigned idx, const FixedArray<float,3> &value) ;
+      void setArg(const unsigned idx, const FixedArray<float,3> &value);
 
       /// Overloaded Kernel argument setter for CLBuffer values (aka arrays/pointers)
-      void setArg(const unsigned idx, const CLBuffer &value) ;
+      void setArg(const unsigned idx, const CLBuffer &value);
 
       /// Overloaded Kernel argument setter for CLImage2D values (aka arrays/pointers)
-      void setArg(const unsigned idx, const CLImage2D &value) ;
+      void setArg(const unsigned idx, const CLImage2D &value);
 
       /// Overloaded Kernel argument setter for dynamic local memory
-      void setArg(const unsigned idx, const LocalMemory &value) ;
+      void setArg(const unsigned idx, const LocalMemory &value);
 
       /// sets mutiple kernel arguments at once
       template<typename A>
-      void setArgs(const A &value)  {
+      void setArgs(const A &value) {
         setArg(0, value);
       }
 
       /// sets mutiple kernel arguments at once
       template<typename A, typename B>
-      void setArgs(const A &valueA, const B &valueB)  {
+      void setArgs(const A &valueA, const B &valueB) {
         setArgs(valueA);
         setArg(1, valueB);
       }
 
       /// sets mutiple kernel arguments at once
       template<typename A, typename B, typename C>
-      void setArgs(const A &valueA, const B &valueB, const C &valueC)  {
+      void setArgs(const A &valueA, const B &valueB, const C &valueC) {
         setArgs(valueA, valueB);
         setArg(2, valueC);
       }
 
       /// sets mutiple kernel arguments at once
       template<typename A, typename B, typename C, typename D>
-      void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD)  {
+      void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD) {
         setArgs(valueA, valueB, valueC);
         setArg(3, valueD);
       }
@@ -183,7 +183,7 @@ namespace icl {
       /// sets mutiple kernel arguments at once
       template<typename A, typename B, typename C, typename D, typename E>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
-                   const E &valueE)  {
+                   const E &valueE) {
         setArgs(valueA, valueB, valueC, valueD);
         setArg(4, valueE);
       }
@@ -191,7 +191,7 @@ namespace icl {
       /// sets mutiple kernel arguments at once
       template<typename A, typename B, typename C, typename D, typename E, typename F>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
-                   const E &valueE, const F &valueF)  {
+                   const E &valueE, const F &valueF) {
         setArgs(valueA, valueB, valueC, valueD, valueE);
         setArg(5, valueF);
       }
@@ -200,8 +200,7 @@ namespace icl {
       template<typename A, typename B, typename C, typename D, typename E, typename F,
                typename G>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
-                   const E &valueE, const F &valueF, const G &valueG)
-                    {
+                   const E &valueE, const F &valueF, const G &valueG) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF);
         setArg(6, valueG);
       }
@@ -210,8 +209,7 @@ namespace icl {
       template<typename A, typename B, typename C, typename D, typename E, typename F,
                typename G, typename H>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
-                   const E &valueE, const F &valueF, const G &valueG, const H &valueH)
-                    {
+                   const E &valueE, const F &valueF, const G &valueG, const H &valueH) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG);
         setArg(7, valueH);
       }
@@ -221,7 +219,7 @@ namespace icl {
                typename G, typename H, typename I>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
-                   const I &valueI)  {
+                   const I &valueI) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH);
         setArg(8, valueI);
       }
@@ -231,7 +229,7 @@ namespace icl {
                typename G, typename H, typename I, typename J>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
-                   const I &valueI, const J &valueJ)  {
+                   const I &valueI, const J &valueJ) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI);
         setArg(9, valueJ);
       }
@@ -241,8 +239,7 @@ namespace icl {
                typename G, typename H, typename I, typename J, typename K>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
-                   const I &valueI, const J &valueJ, const K &valueK)
-                    {
+                   const I &valueI, const J &valueJ, const K &valueK) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ);
         setArg(10, valueK);
@@ -252,8 +249,7 @@ namespace icl {
                typename G, typename H, typename I, typename J, typename K, typename L>
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
-                   const I &valueI, const J &valueJ, const K &valueK, const L &valueL)
-                    {
+                   const I &valueI, const J &valueJ, const K &valueK, const L &valueL) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ, valueK);
         setArg(11, valueL);
@@ -266,7 +262,7 @@ namespace icl {
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
                    const I &valueI, const J &valueJ, const K &valueK, const L &valueL,
-                   const M &valueM)  {
+                   const M &valueM) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ, valueK, valueL);
         setArg(12, valueM);
@@ -279,7 +275,7 @@ namespace icl {
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
                    const I &valueI, const J &valueJ, const K &valueK, const L &valueL,
-                   const M &valueM, const N &valueN)  {
+                   const M &valueM, const N &valueN) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ, valueK, valueL, valueM);
         setArg(13, valueN);
@@ -292,8 +288,7 @@ namespace icl {
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
                    const I &valueI, const J &valueJ, const K &valueK, const L &valueL,
-                   const M &valueM, const N &valueN, const O &valueO)
-                    {
+                   const M &valueM, const N &valueN, const O &valueO) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ, valueK, valueL, valueM, valueN);
         setArg(14, valueO);
@@ -306,8 +301,7 @@ namespace icl {
       void setArgs(const A &valueA, const B &valueB, const C &valueC, const D &valueD,
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
                    const I &valueI, const J &valueJ, const K &valueK, const L &valueL,
-                   const M &valueM, const N &valueN, const O &valueO, const P &valueP)
-                    {
+                   const M &valueM, const N &valueN, const O &valueO, const P &valueP) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ, valueK, valueL, valueM, valueN, valueP);
         setArg(15, valueP);
@@ -321,8 +315,7 @@ namespace icl {
                    const E &valueE, const F &valueF, const G &valueG, const H &valueH,
                    const I &valueI, const J &valueJ, const K &valueK, const L &valueL,
                    const M &valueM, const N &valueN, const O &valueO, const P &valueP,
-                   const Q &valueQ)
-                    {
+                   const Q &valueQ) {
         setArgs(valueA, valueB, valueC, valueD, valueE, valueF, valueG, valueH, valueI,
                 valueJ, valueK, valueL, valueM, valueN, valueP, valueQ);
         setArg(16, valueQ);

--- a/ICLUtils/src/ICLUtils/CLMemoryAssistant.cpp
+++ b/ICLUtils/src/ICLUtils/CLMemoryAssistant.cpp
@@ -37,7 +37,7 @@ namespace icl {
 
 		CLMemoryAssistant::CLMemoryAssistant() {}
 
-		CLMemoryAssistant::CLMemoryAssistant(std::string const &deviceType)  {
+		CLMemoryAssistant::CLMemoryAssistant(std::string const &deviceType) {
 			m_context = CLDeviceContext(deviceType);
 		}
 
@@ -61,8 +61,7 @@ namespace icl {
 		}
 
 		CLBuffer CLMemoryAssistant::createNamedBuffer(MemKeyType const &key, const string &accessMode,
-													  const size_t length, size_t byteDepth, const void *src)
-		 {
+													  const size_t length, size_t byteDepth, const void *src) {
 			if (m_memory_map.find(key) != m_memory_map.end())
 				throw ICLException("CLMemoryAssistant::createNamedBuffer(): Key already in use: " + key);
 			CLBuffer *mem_ptr = 0;
@@ -80,8 +79,7 @@ namespace icl {
 
 		CLImage2D CLMemoryAssistant::createNamedImage2D(MemKeyType const &key, const string &accessMode,
 														const size_t width, const size_t height, const int depth,
-														const int num_channel, const void *src)
-		 {
+														const int num_channel, const void *src) {
 			if (m_memory_map.find(key) != m_memory_map.end())
 				throw ICLException("CLMemoryAssistant::createNamedImage2D(): Key already in use: " + key);
 			CLImage2D *mem_ptr = 0;

--- a/ICLUtils/src/ICLUtils/CLMemoryAssistant.h
+++ b/ICLUtils/src/ICLUtils/CLMemoryAssistant.h
@@ -62,7 +62,7 @@ namespace icl {
 			 * @brief CLMemoryAssistant Creates an instance for the given device type (see CLDeviceContext for details)
 			 * @param deviceType Device to use (see CLDeviceContext for details)
 			 */
-			CLMemoryAssistant(std::string const &deviceType) ;
+			CLMemoryAssistant(std::string const &deviceType);
 
 			/// Destructor
 			~CLMemoryAssistant();
@@ -77,8 +77,7 @@ namespace icl {
 			 * Please see CLDeviceContext::createBuffer() for more details
 			 */
 			CLBuffer createNamedBuffer(MemKeyType const &key, const string &accessMode,
-									   const size_t length, const size_t byteDepth, const void *src=0)
-			;
+									   const size_t length, const size_t byteDepth, const void *src=0);
 
 			/**
 			 * @brief createNamedImage2D creates a Image2D object (internally handled as a CLMemory-pointer)
@@ -88,29 +87,28 @@ namespace icl {
 			 */
 			CLImage2D createNamedImage2D(MemKeyType const &key, const string &accessMode,
 										 const size_t width, const size_t height, const int depth,
-										 const int num_channel, const void *src=0)
-			;
+										 const int num_channel, const void *src=0);
 
 			/**
 			 * @brief operator [] Direct access operator to the internal CLMemory
 			 * @param key The name (std::string) and identifier for this CLMemory instance
 			 * @return CLMemory pointer
 			 */
-			CLMemory *operator[](MemKeyType const &key) ;
+			CLMemory *operator[](MemKeyType const &key);
 
 			/**
 			 * @brief asBuf shortcut to access and cast the internal CLMemory instance (CLBuffer)
 			 * @param key The name (std::string) and identifier for this CLMemory instance
 			 * @return CLImage2D instance
 			 */
-			CLBuffer &asBuf(MemKeyType const &key) ;
+			CLBuffer &asBuf(MemKeyType const &key);
 
 			/**
 			 * @brief asBuf shortcut to access and cast the internal CLMemory instance (CLBuffer)
 			 * @param key The name (std::string) and identifier for this CLMemory instance
 			 * @return CLImage2D instance
 			 */
-			CLImage2D &asImg(MemKeyType const &key) ;
+			CLImage2D &asImg(MemKeyType const &key);
 
 			/**
 			 * @brief keyExist Returns true if the given key exists in this instance

--- a/ICLUtils/src/ICLUtils/CLProgram.cpp
+++ b/ICLUtils/src/ICLUtils/CLProgram.cpp
@@ -53,7 +53,7 @@ namespace icl {
 		bool is_valid;
 		CLDeviceContext deviceContext;
 		cl::Program program;
-		void initProgram(const string &sourceText)  {
+		void initProgram(const string &sourceText) {
 			cl::Program::Sources sources(1, std::make_pair(sourceText.c_str(), 0)); //kernel source
 			program = cl::Program(deviceContext.getContext(), sources);//program (bind context and source)
 			std::vector<cl::Device> deviceList;
@@ -65,7 +65,7 @@ namespace icl {
 			}
 			is_valid = true;
 		}
-		void initDevice(const std::string device_type_str)  {
+		void initDevice(const std::string device_type_str) {
 			try {
 				deviceContext = CLDeviceContext(device_type_str);
 			} catch (cl::Error& error) { //catch openCL errors
@@ -73,7 +73,7 @@ namespace icl {
 			}
 		}
 
-		void initDevice(CLDeviceContext const &device_context)  {
+		void initDevice(CLDeviceContext const &device_context) {
 			try {
 				deviceContext = device_context;
 			} catch (cl::Error& error) { //catch openCL errors
@@ -82,16 +82,16 @@ namespace icl {
 		}
 
 		CLBuffer createBuffer(const string &accessMode, size_t size,
-							  const void *src = 0)  {
+							  const void *src = 0) {
 			return deviceContext.createBuffer(accessMode, size, src);
 		}
 
 		CLImage2D createImage2D(const string &accessMode,  const size_t width, const size_t height,
-								int depth, int num_channel, const void *src=0) {
+								int depth, int num_channel, const void *src=0){
 			return deviceContext.createImage2D(accessMode, width, height, depth, num_channel, src);
 		}
 
-		CLKernel createKernel(const string &id)  {
+		CLKernel createKernel(const string &id) {
 			return CLKernel(id, program, deviceContext.getCommandQueue());
 		}
 
@@ -99,8 +99,7 @@ namespace icl {
 
 	// /////////////////////////////////////////////////////////////////////////////////////////////
 
-	CLProgram::CLProgram(const string deviceType, const string &sourceCode)
-	 {
+	CLProgram::CLProgram(const string deviceType, const string &sourceCode) {
 		impl = new Impl();
 		try {
 			impl->initDevice(deviceType);
@@ -111,8 +110,7 @@ namespace icl {
 		}
 	}
 
-	CLProgram::CLProgram(const string deviceType, ifstream &fileStream)
-		 {
+	CLProgram::CLProgram(const string deviceType, ifstream &fileStream) {
 		impl = new Impl();
 		try {
 			impl->initDevice(deviceType);
@@ -125,8 +123,7 @@ namespace icl {
 		}
 	}
 
-	CLProgram::CLProgram(const string &sourceCode, const CLProgram &parent)
-	 {
+	CLProgram::CLProgram(const string &sourceCode, const CLProgram &parent) {
 		impl = new Impl();
 		try {
 			impl->initDevice(parent.impl->deviceContext);
@@ -137,8 +134,7 @@ namespace icl {
 		}
 	}
 
-	CLProgram::CLProgram(ifstream &fileStream, const CLProgram &parent)
-	 {
+	CLProgram::CLProgram(ifstream &fileStream, const CLProgram &parent) {
 		impl = new Impl();
 		try {
 			impl->initDevice(parent.impl->deviceContext);
@@ -173,7 +169,7 @@ namespace icl {
 		delete impl;
 	}
 
-	CLProgram::CLProgram(const CLDeviceContext &device_context, const string &sourceCode)  {
+	CLProgram::CLProgram(const CLDeviceContext &device_context, const string &sourceCode) {
 		impl = new Impl();
 		try {
 			impl->initDevice(device_context);
@@ -184,7 +180,7 @@ namespace icl {
 		}
 	}
 
-	CLProgram::CLProgram(const CLDeviceContext &device_context, ifstream &fileStream)  {
+	CLProgram::CLProgram(const CLDeviceContext &device_context, ifstream &fileStream) {
 		impl = new Impl();
 		try {
 			impl->initDevice(device_context);
@@ -198,19 +194,19 @@ namespace icl {
 	}
 
 	CLBuffer CLProgram::createBuffer(const string &accessMode, size_t size,
-									 const void *src)  {
+									 const void *src) {
 		return impl->deviceContext.createBuffer(accessMode, size, src);
 	}
 
-	CLImage2D CLProgram::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, const void *src) {
+	CLImage2D CLProgram::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, const void *src){
 		return impl->deviceContext.createImage2D(accessMode, width, height, depth, 1, src);
 	}
 
-	CLImage2D CLProgram::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src) {
+	CLImage2D CLProgram::createImage2D(const string &accessMode,  const size_t width, const size_t height, int depth, int num_channel, const void *src){
 		return impl->deviceContext.createImage2D(accessMode, width, height, depth, num_channel, src);
 	}
 
-	CLKernel CLProgram::createKernel(const string &id)  {
+	CLKernel CLProgram::createKernel(const string &id) {
 		return impl->createKernel(id);
 	}
 

--- a/ICLUtils/src/ICLUtils/CLProgram.h
+++ b/ICLUtils/src/ICLUtils/CLProgram.h
@@ -265,21 +265,21 @@ namespace icl {
       /// Default constructor (creates dummy instance)
       CLProgram();
 
-	  CLProgram(const CLDeviceContext &device_context, const string &sourceCode) ;
+	  CLProgram(const CLDeviceContext &device_context, const string &sourceCode);
 
-	  CLProgram(const CLDeviceContext &device_context, ifstream &fileStream) ;
+	  CLProgram(const CLDeviceContext &device_context, ifstream &fileStream);
 
       /// create CLProgram with given device type (either "gpu" or "cpu") and souce-code
-	  CLProgram(const string deviceType, const string &sourceCode) ;
+	  CLProgram(const string deviceType, const string &sourceCode);
 
       /// create CLProgram with given device type (either "gpu" or "cpu") and souce-code file
-	  CLProgram(const string deviceType, ifstream &fileStream) ;
+	  CLProgram(const string deviceType, ifstream &fileStream);
 
 	  /// create CLProgram with given cl-program parent and souce-code
-	  CLProgram(const string &sourceCode, const CLProgram &parent) ;
+	  CLProgram(const string &sourceCode, const CLProgram &parent);
 
 	  /// create CLProgram with given cl-program parent and souce-code file
-	  CLProgram(ifstream &fileStream, const CLProgram &parent) ;
+	  CLProgram(ifstream &fileStream, const CLProgram &parent);
 
       /// copy constructor (creating shallow copy)
       CLProgram(const CLProgram& other);
@@ -312,7 +312,7 @@ namespace icl {
           Each buffer has a fixed size (given in bytes). Optionally an initial source
           pointer can be passed that is then automatically uploaded to the buffer exisiting
           in the graphics memory.*/
-      CLBuffer createBuffer(const string &accessMode, size_t size,const void *src=0) ;
+      CLBuffer createBuffer(const string &accessMode, size_t size,const void *src=0);
 
 
       /// creates a image2D object for memory exchange with graphics card memory
@@ -329,15 +329,15 @@ namespace icl {
             depth32f = 3, < 32Bit floating point values \n
             depth64f = 4, < 64Bit floating point values \n
           */
-      CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, const void *src=0) ;
+      CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, const void *src=0);
 
-	  CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, int num_channel, const void *src=0) ;
+	  CLImage2D createImage2D(const string &accessMode, const size_t width, const size_t height, int depth, int num_channel, const void *src=0);
 
       /// extract a kernel from the program
       /** Kernels in the CLProgram's source code have to be qualified with the
           __kernel qualifier. The kernel (aka function) name in the OpenCL source code
           is used as id. */
-      CLKernel createKernel(const string &id) ;
+      CLKernel createKernel(const string &id);
 
 	  CLDeviceContext getDeviceContext();
 

--- a/ICLUtils/src/ICLUtils/ConfigFile.cpp
+++ b/ICLUtils/src/ICLUtils/ConfigFile.cpp
@@ -271,7 +271,7 @@ namespace icl{
       }
     }
 
-    void ConfigFile::load(const std::string &filename) {
+    void ConfigFile::load(const std::string &filename){
       // {{{ open
 
       m_doc = SmartPtrBase<XMLDocument,XMLDocumentDelOp>(new XMLDocument);
@@ -303,7 +303,7 @@ namespace icl{
 
     // }}}
 
-    ConfigFile::ConfigFile(std::istream &stream) {
+    ConfigFile::ConfigFile(std::istream &stream){
 
       XMLDocument *doc = new XMLDocument;
       doc->loadNext(stream);
@@ -311,7 +311,7 @@ namespace icl{
     }
 
 
-    void ConfigFile::setRestriction(const std::string &id, const ConfigFile::KeyRestriction &r) {
+    void ConfigFile::setRestriction(const std::string &id, const ConfigFile::KeyRestriction &r){
       // {{{ open
       get_entry_internal(m_sDefaultPrefix+id).restr = SmartPtr<KeyRestriction>(new KeyRestriction(r));
 
@@ -320,7 +320,7 @@ namespace icl{
 
     // }}}
 
-    const ConfigFile::KeyRestriction *ConfigFile::getRestriction(const std::string &id) const {
+    const ConfigFile::KeyRestriction *ConfigFile::getRestriction(const std::string &id) const{
       // {{{ open
       return get_entry_internal(m_sDefaultPrefix+id).restr.get();
     }
@@ -335,7 +335,7 @@ namespace icl{
 
     // }}}
 
-    ConfigFile::ConfigFile(XMLDocument *handle) :
+    ConfigFile::ConfigFile(XMLDocument *handle):
       m_doc(handle){
       load_internal();
     }
@@ -371,7 +371,7 @@ namespace icl{
       *this = ConfigFile();
     }
 
-    bool ConfigFile::check_type_internal(const std::string &id, const std::string &rttiTypeID) const {
+    bool ConfigFile::check_type_internal(const std::string &id, const std::string &rttiTypeID) const{
       const Entry &e = get_entry_internal(m_sDefaultPrefix+id);
       return e.rttiType == rttiTypeID;
       /*
@@ -382,19 +382,18 @@ namespace icl{
       */
     }
 
-    ConfigFile::Entry &ConfigFile::get_entry_internal(const std::string &id) {
+    ConfigFile::Entry &ConfigFile::get_entry_internal(const std::string &id){
       std::map<std::string,Entry>::iterator it = m_entries.find(id);
       if(it == m_entries.end()) throw EntryNotFoundException(id);
       else return it->second;
     }
-    const ConfigFile::Entry &ConfigFile::get_entry_internal(const std::string &id) const {
+    const ConfigFile::Entry &ConfigFile::get_entry_internal(const std::string &id) const{
       return const_cast<ConfigFile*>(this)->get_entry_internal(id);
     }
 
 
 
-    void ConfigFile::set_internal(const std::string &idIn, const std::string &val, const std::string &type)
-      {
+    void ConfigFile::set_internal(const std::string &idIn, const std::string &val, const std::string &type){
       Maps &maps = getMapsInstanceRef();
       std::map<std::string,std::string>::iterator it = maps.typeMap.find(type);
       if(it == maps.typeMap.end()) throw UnregisteredTypeException(type);
@@ -441,7 +440,7 @@ namespace icl{
       return Data(id,*this);
     }
 
-    const ConfigFile::Data ConfigFile::operator[](const std::string &id) const {
+    const ConfigFile::Data ConfigFile::operator[](const std::string &id) const{
       if(!contains(id)){
         throw EntryNotFoundException(m_sDefaultPrefix+id);
       }

--- a/ICLUtils/src/ICLUtils/ConfigFile.h
+++ b/ICLUtils/src/ICLUtils/ConfigFile.h
@@ -177,21 +177,21 @@ namespace icl{
       struct EntryNotFoundException : public ICLException{
         EntryNotFoundException(const std::string &entryName):
         ICLException("Entry " + entryName+" could not be found!"){}
-        virtual ~EntryNotFoundException() throw(){}
+        virtual ~EntryNotFoundException() noexcept{}
       };
 
       /// Internal exception type, thrown if an entry type missmatch occurs
       struct InvalidTypeException : public ICLException{
         InvalidTypeException(const std::string &entryName, const std::string &typeName):
         ICLException("Invalid type " + typeName + " (entry " + entryName + ")"){};
-        virtual ~InvalidTypeException() throw() {}
+        virtual ~InvalidTypeException() noexcept {}
       };
 
       /// thrown if unregistered types are used
       struct UnregisteredTypeException : public ICLException{
         UnregisteredTypeException(const std::string &rttiID):
         ICLException("type with RTTI ID " + rttiID + " is not registered"){}
-        ~UnregisteredTypeException() throw(){}
+        ~UnregisteredTypeException() noexcept{}
       };
 
       private:
@@ -217,7 +217,7 @@ namespace icl{
 
       /// internally used utitlity function
       template<class T>
-      static const std::string &get_type_name() {
+      static const std::string &get_type_name(){
         static const std::string &rttiID = get_rtti_type_id<T>();
         if(!type_registered_by_rtti(rttiID)) throw UnregisteredTypeException(rttiID);
         static const std::string &name = getMapsInstanceRef().typeMap[rttiID];
@@ -233,13 +233,12 @@ namespace icl{
 
       /// internally used utitlity function (id must be given without prefix)
       template<class T>
-      inline bool check_type(const std::string &id) const {
+      inline bool check_type(const std::string &id) const{
         return check_type_internal(id,get_rtti_type_id<T>());
       }
 
       /// internally used utitlity function
-      bool check_type_internal(const std::string &id, const std::string &rttiTypeID) const
-      ;
+      bool check_type_internal(const std::string &id, const std::string &rttiTypeID) const;
 
       /// internally used utitlity function
       static bool type_registered_by_rtti(const std::string &rttiID){
@@ -349,14 +348,14 @@ namespace icl{
         /** This automatic cast automatically detects the destination (lvalue) type an calls the
             appropiate parse<T> function */
         template<class T>
-        operator T() const {
+        operator T() const{
           return cf->get<T>(id);
         }
 
         /// explicit cast into given type
         /** Sometimes, the implicit automatic cast is not allowed due to ambiguities */
         template<class T>
-        T as() const {
+        T as() const{
           return cf->get<T>(id);
         }
 
@@ -375,7 +374,7 @@ namespace icl{
             If given type T is not registered, an UnregisteredTypeException is thrown
         */
         template<class T>
-        Data &operator=(const T &t) {
+        Data &operator=(const T &t){
           cf->set(id,t);
           return *this;
         }
@@ -391,7 +390,7 @@ namespace icl{
 
       /// main access function to datastore entries (const)
       /** As above, but only for reading ... */
-      const Data operator[](const std::string &id) const ;
+      const Data operator[](const std::string &id) const;
 
       /// returns all data entries, that match the given regex
       /** note, the current default prefix is <b>not</b> used here */
@@ -432,7 +431,7 @@ namespace icl{
           type "double" by default:
       */
       template<class T>
-      void set(const std::string &id, const T &val) {
+      void set(const std::string &id, const T &val){
         set_internal(id,str(val),get_rtti_type_id<T>());
       }
 
@@ -448,7 +447,7 @@ namespace icl{
              data store -> throws an instance of UnregisteredTypeException
       */
       template<class T>
-      inline T get(const std::string &idIn) const {
+      inline T get(const std::string &idIn) const{
         if(!contains(idIn)) throw EntryNotFoundException(m_sDefaultPrefix+idIn);
         if(!check_type<T>(idIn)) throw InvalidTypeException(m_sDefaultPrefix+idIn,get_type_name<T>());
         return parse<T>(m_entries.find(m_sDefaultPrefix+idIn)->second.value);
@@ -458,7 +457,7 @@ namespace icl{
       /** Like the function above, except it uses a default value if given key cannot be found
       */
       template<class T>
-      inline T get(const std::string &idIn,const T &def) const {
+      inline T get(const std::string &idIn,const T &def) const{
         if(!contains(idIn)) return def;
         if(!check_type<T>(idIn)) throw InvalidTypeException(m_sDefaultPrefix+idIn,get_type_name<T>());
         return parse<T>(m_entries.find(m_sDefaultPrefix+idIn)->second.value);
@@ -475,13 +474,13 @@ namespace icl{
 
       /// applies get on the static config instances
       template<class T>
-      static inline T sget(const std::string &id) {
+      static inline T sget(const std::string &id){
         return getConfig().get<T>(id);
       }
 
       /// applies get on the static config instances (with default)
       template<class T>
-      static inline T sget(const std::string &id,const T &def) {
+      static inline T sget(const std::string &id,const T &def){
         return getConfig().get<T>(id,def);
       }
 
@@ -515,11 +514,11 @@ namespace icl{
       /// defined the range for given number-type-valued key
       /** This feature is used by the ConfigFileGUI to create appropriate slider
           ranges if requested */
-      void setRestriction(const std::string &id, const KeyRestriction &r) ;
+      void setRestriction(const std::string &id, const KeyRestriction &r);
 
       /// returns predefined range for given id (or 0 if no range was defined for this key)
       /** This feature is only used by the config file GUI */
-      const KeyRestriction *getRestriction(const std::string &id) const ;
+      const KeyRestriction *getRestriction(const std::string &id) const;
 
       /// internal utility structure for contained data
       struct Entry{
@@ -573,13 +572,13 @@ namespace icl{
       void load_internal();
 
       /// internal utility function
-      Entry &get_entry_internal(const std::string &id) ;
+      Entry &get_entry_internal(const std::string &id);
 
       /// internal utility function
-      const Entry &get_entry_internal(const std::string &id) const ;
+      const Entry &get_entry_internal(const std::string &id) const;
 
       /// internal utility function
-      void set_internal(const std::string &id, const std::string &val, const std::string &type) ;
+      void set_internal(const std::string &id, const std::string &val, const std::string &type);
 
       /// internally synchronized an add- or a set call
       static void add_to_doc(pugi::xml_document &h,const std::string &id,const std::string &type,
@@ -608,12 +607,10 @@ namespace icl{
     ICLUtils_API std::ostream &operator<<(std::ostream &s, const ConfigFile &cf);
 
     /** \cond */
-    template<> inline ConfigFile::Data &ConfigFile::Data::operator=(char * const &t)
-    {
+    template<> inline ConfigFile::Data &ConfigFile::Data::operator=(char * const &t){
       return ConfigFile::Data::operator=(std::string(t));
     }
-    template<> inline ConfigFile::Data &ConfigFile::Data::operator=(const char * const &t)
-    {
+    template<> inline ConfigFile::Data &ConfigFile::Data::operator=(const char * const &t){
       return ConfigFile::Data::operator=(std::string(t));
     }
     /** \endcond */

--- a/ICLUtils/src/ICLUtils/Configurable.cpp
+++ b/ICLUtils/src/ICLUtils/Configurable.cpp
@@ -48,7 +48,7 @@ namespace icl{
       return prefix+str(i.value++);
     }
 
-     Configurable::Property &Configurable::prop(const std::string &propertyName) {
+     Configurable::Property &Configurable::prop(const std::string &propertyName){
       std::map<std::string,Property>::iterator it = m_properties.find(propertyName);
       if(it == m_properties.end()){
         throw ICLException("Property " + str(propertyName) + " is not supported");
@@ -83,7 +83,7 @@ namespace icl{
       throw ICLException("removeChildConfigurable: is not yet implemented");
     }
 
-    const Configurable::Property &Configurable::prop(const std::string &propertyName) const {
+    const Configurable::Property &Configurable::prop(const std::string &propertyName) const{
       return const_cast<Configurable*>(this)->prop(propertyName);
     }
 
@@ -107,7 +107,7 @@ namespace icl{
 
     void Configurable::addProperty(const std::string &name, const std::string &type,
                                    const std::string &info, const Any &value,
-                                   int volatileness, const std::string &tooltip) {
+                                   int volatileness, const std::string &tooltip){
       try{
         prop(name);
         throw ICLException("Unable to add property " + name + " because it is already used");
@@ -130,7 +130,7 @@ namespace icl{
       }
     }
 
-    Configurable::Configurable(const std::string &ID, bool ordered) 
+    Configurable::Configurable(const std::string &ID, bool ordered)
       : m_isOrdered(ordered), m_elderConfigurable(NULL), m_ID(ID){
       if(ID.length()){
         if(get(ID)) throw ICLException(str("Configurable(")+ID+"): given ID is already used");
@@ -168,7 +168,7 @@ namespace icl{
     }
 
 
-    void Configurable::setConfigurableID(const std::string &ID) {
+    void Configurable::setConfigurableID(const std::string &ID){
       if(m_ID.length()){
         std::map<std::string,Configurable*>::iterator it = m_instances.find(m_ID);
         if(it == m_instances.end()){
@@ -227,7 +227,7 @@ namespace icl{
       return find(l.begin(),l.end(),propertyName) != l.end();
     }
 
-    void Configurable::setPropertyValue(const std::string &propertyName, const Any &value) {
+    void Configurable::setPropertyValue(const std::string &propertyName, const Any &value){
       Property &p = prop(propertyName);
       if(p.configurable != this){
         p.configurable->setPropertyValue(propertyName.substr(p.childPrefix.length()),value);
@@ -408,7 +408,7 @@ namespace icl{
     }
 
     void Configurable::adaptProperty(const std::string &name,const std::string &newType,
-                                     const std::string &newInfo, const std::string &newToolTip) {
+                                     const std::string &newInfo, const std::string &newToolTip){
       Property &p = prop(name);
       if(p.configurable != this){
         p.configurable->adaptProperty(name.substr(p.childPrefix.length()),newType,newInfo, newToolTip);
@@ -427,7 +427,7 @@ namespace icl{
     }
 
     void Configurable::register_configurable_type(const std::string &classname,
-                                                  Function<Configurable*> creator) {
+                                                  Function<Configurable*> creator){
       CRM &crm = get_configurable_registration_map();
       CRM::iterator it = crm.find(classname);
       if(it != crm.end()) throw ICLException("unable to register configurable " + classname + ": name already in use");
@@ -443,7 +443,7 @@ namespace icl{
       return all;
     }
 
-    Configurable *Configurable::create_configurable(const std::string &classname) {
+    Configurable *Configurable::create_configurable(const std::string &classname){
       CRM &crm = get_configurable_registration_map();
       CRM::iterator it = crm.find(classname);
       if(it == crm.end()) throw ICLException("unable to create configurable " + classname + ": name not registered");

--- a/ICLUtils/src/ICLUtils/Configurable.h
+++ b/ICLUtils/src/ICLUtils/Configurable.h
@@ -257,7 +257,7 @@ namespace icl{
           */
       void addProperty(const std::string &name, const std::string &type,
                        const std::string &info, const Any &value=Any(),
-                       const int volatileness=0, const std::string &tooltip=std::string()) ;
+                       const int volatileness=0, const std::string &tooltip=std::string());
 
       /// This adds another configurable as child
       /** Child configurables can be added with a given prefix. If this prefix is not "",
@@ -272,18 +272,18 @@ namespace icl{
 
       /// this CAN be used e.g. to store a property value in internal property-list
       /** Throws an exception if the given propertyName is not supported */
-      Property &prop(const std::string &propertyName) ;
+      Property &prop(const std::string &propertyName);
 
       /// this CAN be used e.g. to store a property value in internal property-list
       /** Throws an exception if the given propertyName is not supported */
-      const Property &prop(const std::string &propertyName) const ;
+      const Property &prop(const std::string &propertyName) const;
 
       /// create this configurable with given ID
       /** all instantiated configurables are globally accessible by static getter functions
           If given ID is "", then this configurable is not added to the static list.
           Configurables can later be put into the static list by using setConfigurableID
           **/
-      Configurable(const std::string &ID="", bool ordered=true) ;
+      Configurable(const std::string &ID="", bool ordered=true);
 
       public:
 
@@ -300,7 +300,7 @@ namespace icl{
 
       /// sets the ID of this configurable
       /** The ID is used for accessing the configurable globally*/
-      void setConfigurableID(const std::string &ID) ;
+      void setConfigurableID(const std::string &ID);
 
       /// returns the configurables static ID
       inline const std::string &getConfigurableID() const{
@@ -343,7 +343,7 @@ namespace icl{
           You can also set a properties type from range:spinbox to range:slider
           */
       virtual void adaptProperty(const std::string &name, const std::string &newType,
-                                 const std::string &newInfo, const std::string &newToolTip) ;
+                                 const std::string &newInfo, const std::string &newToolTip);
 
 
       /// this function can be used in subclasses to create a default ID
@@ -393,7 +393,7 @@ namespace icl{
           call all registered callbacks.
           If the property is actually owned by a child-configurable,
           the function forwards to that configurable */
-      virtual void setPropertyValue(const std::string &propertyName, const Any &value) ;
+      virtual void setPropertyValue(const std::string &propertyName, const Any &value);
 
       /// returns a list of All properties, that can be set using setProperty
       /** This function should usually not be used. Instead, you should call getPropertyListWithoutDeactivated
@@ -488,7 +488,7 @@ namespace icl{
 
       /// registers a configurable type
       /** @see \ref REG */
-      static void register_configurable_type(const std::string &classname, Function<Configurable*> creator) ;
+      static void register_configurable_type(const std::string &classname, Function<Configurable*> creator);
 
       /// returns a list of all registered configurable classnames
       /** @see \ref REG */
@@ -496,7 +496,7 @@ namespace icl{
 
       /// creates a configurable by given name
       /** @see \ref REG */
-      static Configurable *create_configurable(const std::string &classname) ;
+      static Configurable *create_configurable(const std::string &classname);
     };
 
     /// registration macro for configurables

--- a/ICLUtils/src/ICLUtils/ConfigurableProxy.h
+++ b/ICLUtils/src/ICLUtils/ConfigurableProxy.h
@@ -64,7 +64,7 @@ namespace icl{
         }
 
         /// sets a property value
-        void setPropertyValue(const std::string &propertyName, const Any &value) {
+        void setPropertyValue(const std::string &propertyName, const Any &value){
           getInternalConfigurable() -> setPropertyValue(propertyName, value);
         }
 

--- a/ICLUtils/src/ICLUtils/Exception.h
+++ b/ICLUtils/src/ICLUtils/Exception.h
@@ -42,101 +42,101 @@ namespace icl {
     class ICLException : public std::runtime_error
     {
     public:
-      ICLException(const std::string &msg) throw() : runtime_error(msg){}
+      ICLException(const std::string &msg) noexcept : runtime_error(msg){}
       ICLUtils_API void report();
     };
 
     /// Exception for invalid file formats \ingroup EXCEPT
     class InvalidFileFormatException : public ICLException {
     public:
-      InvalidFileFormatException () throw() :
+      InvalidFileFormatException () noexcept :
          ICLException ("invalid file format") {}
-         InvalidFileFormatException (const std::string &hint) throw() :
+         InvalidFileFormatException (const std::string &hint) noexcept :
          ICLException ("invalid file format :(" + hint + ")") {}
-      virtual ~InvalidFileFormatException() throw() {}
+      virtual ~InvalidFileFormatException() noexcept {}
     };
 
     /// Exception thrown if a file could not be opend \ingroup EXCEPT
     class FileOpenException : public ICLException {
     public:
-      FileOpenException (const std::string& sFileName) throw() :
+      FileOpenException (const std::string& sFileName) noexcept :
          ICLException (std::string("Can't open file: ") + sFileName) {}
-      virtual ~FileOpenException() throw() {}
+      virtual ~FileOpenException() noexcept {}
     };
 
     /// Exception thrown if a file could not be found \ingroup EXCEPT
     class FileNotFoundException : public ICLException {
       public:
-      FileNotFoundException (const std::string& sFileName) throw() :
+      FileNotFoundException (const std::string& sFileName) noexcept :
       ICLException (std::string("File not found: ") + sFileName) {}
-      virtual ~FileNotFoundException() throw() {}
+      virtual ~FileNotFoundException() noexcept {}
     };
 
     /// Exception thrown if a file could not be read properly \ingroup EXCEPT
     class InvalidFileException : public ICLException {
       public:
-      InvalidFileException (const std::string& sFileName) throw() :
+      InvalidFileException (const std::string& sFileName) noexcept :
       ICLException (std::string("Invalied file: ") + sFileName) {}
-      virtual ~InvalidFileException() throw() {}
+      virtual ~InvalidFileException() noexcept {}
     };
 
     /// Exception called if an image gets invalid params \ingroup EXCEPT
     class InvalidImgParamException : public ICLException {
       public:
-      InvalidImgParamException(const std::string &param) throw():
+      InvalidImgParamException(const std::string &param) noexcept:
         ICLException(std::string("Invalid Img-Parameter: ")+param) {}
-      virtual ~InvalidImgParamException() throw() {}
+      virtual ~InvalidImgParamException() noexcept {}
     };
 
     /// Exception thrown if a function should process an unsupported image format \ingroup EXCEPT
     class InvalidFormatException : public ICLException {
       public:
-      InvalidFormatException(const std::string &functionName) throw():
+      InvalidFormatException(const std::string &functionName) noexcept:
         ICLException(std::string("Invalid Format in: ")+functionName) {}
-      virtual ~InvalidFormatException() throw() {}
+      virtual ~InvalidFormatException() noexcept {}
     };
 
     /// Exception thrown if a function should process an unsupported image depth \ingroup EXCEPT
     class InvalidDepthException : public ICLException {
       public:
-      InvalidDepthException(const std::string &functionName) throw():
+      InvalidDepthException(const std::string &functionName) noexcept:
         ICLException(std::string("Invalid Depth in: ")+functionName) {}
-      virtual ~InvalidDepthException() throw() {}
+      virtual ~InvalidDepthException() noexcept {}
     };
 
 		/// Exception thrown if a function should process an unsupported image depth \ingroup EXCEPT
 		class InvalidNumChannelException : public ICLException {
 			public:
-			InvalidNumChannelException(const std::string &functionName) throw():
+			InvalidNumChannelException(const std::string &functionName) noexcept:
 				ICLException(std::string("Invalid number of Channels in: ")+functionName) {}
-			virtual ~InvalidNumChannelException() throw() {}
+			virtual ~InvalidNumChannelException() noexcept {}
 		};
 
     /// Exception thrown if a function should process an unsupported sizes (e.g. with negative dim..) \ingroup EXCEPT
     class InvalidSizeException : public ICLException {
       public:
-      InvalidSizeException(const std::string &functionName) throw():
+      InvalidSizeException(const std::string &functionName) noexcept:
         ICLException(std::string("Invalid Size in: ")+functionName) {}
-      virtual ~InvalidSizeException() throw() {}
+      virtual ~InvalidSizeException() noexcept {}
     };
 
     /// Exception thrown if a string is parsed into a specific type (or something) \ingroup EXCEPT
     class ParseException : public ICLException {
       public:
-      ParseException(const std::string &whatToParse) throw():
+      ParseException(const std::string &whatToParse) noexcept:
         ICLException(std::string("unable to parse: ")+whatToParse) {}
-      ParseException(const std::string &function, const std::string &line, const std::string &hint="") throw():
+      ParseException(const std::string &function, const std::string &line, const std::string &hint="") noexcept:
         ICLException("Parsing error in: "+function+" line:"+line + hint){}
-      virtual ~ParseException() throw() {}
+      virtual ~ParseException() noexcept {}
     };
 
     /// Thrown by iclStringUtils::match if regular Expression is not valid \ingroup EXCEPT
     class InvalidRegularExpressionException : public ICLException{
       public:
-      InvalidRegularExpressionException(const std::string &regex) throw():
+      InvalidRegularExpressionException(const std::string &regex) noexcept:
       ICLException("invalid regular expression: '"+regex+"'"){
       }
-      virtual ~InvalidRegularExpressionException() throw(){}
+      virtual ~InvalidRegularExpressionException() noexcept{}
     };
 
   #define ICL_FILE_LOCATION  (std::string(__FUNCTION__) + "(" + __FILE__ + ")")

--- a/ICLUtils/src/ICLUtils/IppInterface.h
+++ b/ICLUtils/src/ICLUtils/IppInterface.h
@@ -50,15 +50,15 @@ namespace icl{
 
     class ICLDynamicLibLoadException : ICLException {
       public:
-        ICLDynamicLibLoadException (const char* error) throw() :
+        ICLDynamicLibLoadException (const char* error) noexcept :
           ICLException (std::string("Can't load library: ") + std::string(error)) {}
-        virtual ~ICLDynamicLibLoadException() throw() {}
+        virtual ~ICLDynamicLibLoadException() noexcept {}
     };
     class ICLDynamicFunctionLoadException : ICLException {
       public:
-        ICLDynamicFunctionLoadException (const char* error) throw() :
+        ICLDynamicFunctionLoadException (const char* error) noexcept :
           ICLException (std::string("Can't load function from library: ") + std::string(error)) {}
-        virtual ~ICLDynamicFunctionLoadException() throw() {}
+        virtual ~ICLDynamicFunctionLoadException() noexcept {}
     };
 
     class IppInterface : Uncopyable{

--- a/ICLUtils/src/ICLUtils/ParamList.h
+++ b/ICLUtils/src/ICLUtils/ParamList.h
@@ -55,16 +55,16 @@ namespace icl{
       /// creates a param list from a single given string
       /** The string is a comma seperated list of key=value tokens. Both
           comma and the '='-character can be escaped using backslash */
-      inline ParamList(const std::string &commaSepKeyValueString) {
+      inline ParamList(const std::string &commaSepKeyValueString){
         init(commaSepKeyValueString);
       }
 
       /// this allows for implicit creation of a ParamList instance from a given const char *
-      inline ParamList(const char *commaSepKeyValueString) {
+      inline ParamList(const char *commaSepKeyValueString){
         init(commaSepKeyValueString);
       }
 
-      inline void init(const std::string commaSepKeyValueString) {
+      inline void init(const std::string commaSepKeyValueString){
         std::vector<std::string> ts = tok(commaSepKeyValueString,",",true,'\\');
         for(size_t i=0;i<ts.size();++i){
           std::vector<std::string> kv = tok(ts[i],"=",true,'\\');
@@ -111,7 +111,7 @@ namespace icl{
       }
 
       /// extension for the unconst operator that is provided by the std::map class
-      inline const Any &operator[](const Key &key) const {
+      inline const Any &operator[](const Key &key) const{
         const_iterator it = find(key);
         if(it == end()) throw ICLException("error in ParamList::operator[](key) with key=" + key + ": key not found!");
         return it->second;

--- a/ICLUtils/src/ICLUtils/PluginRegister.h
+++ b/ICLUtils/src/ICLUtils/PluginRegister.h
@@ -73,8 +73,7 @@ namespace icl{
       }
 
       /// creates an instance (or throws
-      inline T *createInstance(const std::string &name, const Data &data)
-        {
+      inline T *createInstance(const std::string &name, const Data &data){
         typename std::map<std::string,Plugin>::iterator it = plugins.find(name);
         if(it == plugins.end()){
           std::ostringstream all;

--- a/ICLUtils/src/ICLUtils/PluginRegister.h
+++ b/ICLUtils/src/ICLUtils/PluginRegister.h
@@ -72,7 +72,7 @@ namespace icl{
         plugins[name] = p;
       }
 
-      /// creates an instance (or throws
+      /// creates an instance (or throws)
       inline T *createInstance(const std::string &name, const Data &data){
         typename std::map<std::string,Plugin>::iterator it = plugins.find(name);
         if(it == plugins.end()){

--- a/ICLUtils/src/ICLUtils/ProgArg.cpp
+++ b/ICLUtils/src/ICLUtils/ProgArg.cpp
@@ -158,7 +158,7 @@ namespace icl{
       AllowedArg *allowed;
       std::vector<std::string> subargs;
 
-      void checkArgCountThrow() const {
+      void checkArgCountThrow() const{
         if(allowed->subargcount != (int)subargs.size()){
           THROW_ProgArgException("sub-argument typecheck for arg '" + arg()
                                  +"' failed (invalid subargument count. Expected "
@@ -312,7 +312,7 @@ namespace icl{
         }
       }
 
-      void parse_arg(const std::string &arg, AllowedArg *aa) {
+      void parse_arg(const std::string &arg, AllowedArg *aa){
         std::vector<std::string> ad = tok(arg,"=",true,'\\');
         size_t s = ad.size();
         if(s<1||s>2) THROW_ProgArgException("empty arg token or motre than one unquoted '=' found in arg '" + arg +"'");
@@ -321,7 +321,7 @@ namespace icl{
         aa->defs.push_back(s==1?std::string():ad[1]);
       }
       // ownership is passed and then managed by a smartptr instance
-      void add(AllowedArg *arg) {
+      void add(AllowedArg *arg){
         allowed.push_back(arg);
         for(unsigned int i=0;i<arg->names.size();++i){
           if(allowedMap.find(arg->names[i]) != allowedMap.end()){
@@ -331,7 +331,7 @@ namespace icl{
         }
       }
 
-      void add(GivenArg *g) {
+      void add(GivenArg *g){
         std::map<std::string,GivenArg*>::iterator it = given.find(g->arg());
         if(it != given.end()) THROW_ProgArgException("argument '" + g->arg() + "' was given at least twice");
         for(unsigned int i=0;i<g->allowed->names.size();++i){
@@ -363,7 +363,7 @@ namespace icl{
     ProgArgContext *ProgArgContext::s_context = 0;
     std::map<std::string,std::string> ProgArgContext::explanations;
 
-    void pa_init_internal(const std::string &sIn, ProgArgContext &context) {
+    void pa_init_internal(const std::string &sIn, ProgArgContext &context){
 
 
       std::string s = sIn;
@@ -537,7 +537,7 @@ namespace icl{
       return danglingOnly ? context.dangling.size() : context.all.size();
     }
 
-    const std::string &pa_subarg_internal(const ProgArgData &pa) {
+    const std::string &pa_subarg_internal(const ProgArgData &pa){
       ProgArgContext &context = *ProgArgContext::getInstance(__FUNCTION__);
       if(!pa.id.length()){
         const std::vector<std::string> &l = pa.danglingOnly ? context.dangling : context.all;
@@ -589,17 +589,17 @@ namespace icl{
       return dummy;
     }
 
-    int ProgArg::n() const {
+    int ProgArg::n() const{
       GivenArg *g = ProgArgContext::getInstance(__FUNCTION__)->findGivenArg(id);
       return g ? (int)g->subargs.size() : 0;
     }
 
-    Any ProgArg::operator[](int idx) const {
+    Any ProgArg::operator[](int idx) const{
       return *pa(id,idx);
     }
 
 
-    bool pa_defined_internal(const ProgArgData &pa) {
+    bool pa_defined_internal(const ProgArgData &pa){
       ProgArgContext &context = *ProgArgContext::getInstance(__FUNCTION__);
       if(!pa.id.length()){
         const std::vector<std::string> &l = pa.danglingOnly ? context.dangling : context.all;

--- a/ICLUtils/src/ICLUtils/ProgArg.h
+++ b/ICLUtils/src/ICLUtils/ProgArg.h
@@ -147,7 +147,7 @@ namespace icl{
     /** \cond */
     // explicit specialization for bool types (returns whether the arg was actually given)
     template<>
-    inline ProgArg::operator bool() const {
+    inline ProgArg::operator bool() const{
       return pa_defined_internal(*this);
     }
 

--- a/ICLUtils/src/ICLUtils/PugiXML.cpp
+++ b/ICLUtils/src/ICLUtils/PugiXML.cpp
@@ -6851,7 +6851,7 @@ namespace pugi
     PugiXMLException(const std::string &text) : std::runtime_error(text){}
   };
 
-  static inline void seek(char search, std::basic_istream<char, std::char_traits<char> >& stream, std::vector<char> &read) {
+  static inline void seek(char search, std::basic_istream<char, std::char_traits<char> >& stream, std::vector<char> &read){
     char c;
     while(stream.get(c)){
       read.push_back(c);
@@ -11787,7 +11787,7 @@ namespace pugi
     assert(_result.error);
   }
 
-  PUGI__FN const char* xpath_exception::what() const throw()
+  PUGI__FN const char* xpath_exception::what() const noexcept
   {
     return _result.error;
   }

--- a/ICLUtils/src/ICLUtils/PugiXML.h
+++ b/ICLUtils/src/ICLUtils/PugiXML.h
@@ -1243,7 +1243,7 @@ namespace pugi
     explicit xpath_exception(const xpath_parse_result& result);
 
     // Get error message
-    virtual const char* what() const throw();
+    virtual const char* what() const noexcept;
 
     // Get parse result
     const xpath_parse_result& result() const;

--- a/ICLUtils/src/ICLUtils/Random.h
+++ b/ICLUtils/src/ICLUtils/Random.h
@@ -208,8 +208,7 @@ namespace icl{
   /* }}} */
 
     inline std::vector<int> get_random_index_subset(int containerSize,
-                                                    int subsetSize)
-      {
+                                                    int subsetSize){
       if(subsetSize > containerSize){
         throw ICLException("get_random_index_subset: subsetsize must be <= containerSize");
       }
@@ -220,8 +219,7 @@ namespace icl{
     }
 
     template<class T>
-    inline std::vector<T> get_random_subset(const std::vector<T> &s, int subsetSize)
-      {
+    inline std::vector<T> get_random_subset(const std::vector<T> &s, int subsetSize){
       std::vector<int> indices = get_random_index_subset(s.size(), subsetSize);
       std::vector<T> subset(subsetSize);
       for(int i=0;i<subsetSize;++i){
@@ -232,8 +230,7 @@ namespace icl{
 
     template<class T>
     inline void get_random_subset(const std::vector<T> &s, int subsetSize,
-                                  std::vector<T> &subset)
-      {
+                                  std::vector<T> &subset){
       std::vector<int> indices = get_random_index_subset(s.size(), subsetSize);
       subset.resize(subsetSize);
       for(int i=0;i<subsetSize;++i){
@@ -243,8 +240,7 @@ namespace icl{
 
     template<class T>
     inline void get_random_subset(const std::vector<T> &s, int subsetSize,
-                                  std::vector<T> &subset, std::vector<int> &indices)
-      {
+                                  std::vector<T> &subset, std::vector<int> &indices){
       indices = get_random_index_subset(s.size(), subsetSize);
       subset.resize(subsetSize);
       for(int i=0;i<subsetSize;++i){

--- a/ICLUtils/src/ICLUtils/StringUtils.cpp
+++ b/ICLUtils/src/ICLUtils/StringUtils.cpp
@@ -217,8 +217,7 @@ namespace icl{
     }
 
 
-    MatchResult match(const std::string &text, const std::string &regexIn, int num)
-      {
+    MatchResult match(const std::string &text, const std::string &regexIn, int num){
       string regexSave = regexIn;
   //#ifndef ICL_SYSTEM_WINDOWS // TODOW
       char *regex = const_cast<char*>(regexSave.c_str());

--- a/ICLUtils/src/ICLUtils/StringUtils.h
+++ b/ICLUtils/src/ICLUtils/StringUtils.h
@@ -289,8 +289,7 @@ namespace icl{
                                 the whole pattern match is submatches[0] in the resulting MatchResult
                                 if numSubMatches is at least 1
         */
-    ICLUtils_API MatchResult match(const std::string &text, const std::string &regex, int numSubMatches = 0)
-      ;
+    ICLUtils_API MatchResult match(const std::string &text, const std::string &regex, int numSubMatches = 0);
 
 
     /// converts a Time::value_type (long int) into a string

--- a/doc/icl-manual/modules/qt.rst
+++ b/doc/icl-manual/modules/qt.rst
@@ -375,9 +375,9 @@ type-checked assignment. For this, the :icl:`qt::DataStore::Data`
 instance returned by the index operator provides template-based
 assignment and implicit cast operators::
   
-  template<class T> void operator=(const T &t) ;
+  template<class T> void operator=(const T &t) throw (UnassignableTypeException);
 
-  template<class T> operator T() const ;
+  template<class T> operator T() const throw (UnassignableTypeException);
   
 Internally, contained GUI entries, such as a slider value, are
 registered with an RTTI-type, which is checked whenever one of these

--- a/doc/icl-manual/modules/qt.rst
+++ b/doc/icl-manual/modules/qt.rst
@@ -375,9 +375,9 @@ type-checked assignment. For this, the :icl:`qt::DataStore::Data`
 instance returned by the index operator provides template-based
 assignment and implicit cast operators::
   
-  template<class T> void operator=(const T &t) throw (UnassignableTypeException);
+  template<class T> void operator=(const T &t);
 
-  template<class T> operator T() const throw (UnassignableTypeException);
+  template<class T> operator T() const;
   
 Internally, contained GUI entries, such as a slider value, are
 registered with an RTTI-type, which is checked whenever one of these


### PR DESCRIPTION
Cleaning up dynamic throw specifications removed some important code snippets as well.
I have done the cleanup again, using

- throw() -> noexcept
  find . -iname '*.cpp' -exec perl -i -p0e 's/(\)(\s*const)?)\s*throw\s*\(\s*\)/\1 noexcept/smg' {} \;
  find . -iname '*.h' -exec perl -i -p0e 's/(\)(\s*const)?)\s*throw\s*\(\s*\)/\1 noexcept/smg' {} \;

- throw(*) ->
  find . -iname '*.cpp' -exec perl -i -p0e 's/(\)(\s*const)?)\s*throw\s*\([^)]*\)/\1/smg' {} \;
  find . -iname '*.h' -exec perl -i -p0e 's/(\)(\s*const)?)\s*throw\s*\([^)]*\)/\1/smg' {} \;

This PR comprises all resulting diffs. Most of them are whitespace changes.